### PR TITLE
Improve CI for building and pushing Helm charts to registry.cern.ch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,9 +68,7 @@ deploy:
     - |
         set -x
         CHART=$(echo $CI_COMMIT_TAG | awk -F '@' '{print $1}')
-        for chart in $(ls -d */Chart.yaml | xargs dirname); do
-            helm dependency update ${chart}
-            helm push ${chart}/ ${HELM_CHART_REPO}
-        done
+        helm dependency update ${CHART}
+        helm push ${CHART}/ ${HELM_CHART_REPO}
   only:
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,20 @@ deploy:
     - |
         set -x
         CHART=$(echo $CI_COMMIT_TAG | awk -F '@' '{print $1}')
-        helm dependency update ${CHART}
-        helm push ${CHART}/ ${HELM_CHART_REPO}
+        TAG_VERSION=$(echo $CI_COMMIT_TAG | awk -F '@' '{print $2}')
+
+        test -f ${CHART}/Chart.yaml
+        if [ $? -ne 0 ]; then
+          echo "ERROR: Chart.yaml does not exist for chart ${CHART}"
+          exit 1
+        fi
+        YAML_VERSION=$(cat ${CHART}/Chart.yaml | grep ^version | awk '{print $2}')
+        if [[ "$TAG_VERSION" == "$YAML_VERSION" ]]; then
+          helm dependency update ${CHART}
+          helm push ${CHART}/ ${HELM_CHART_REPO}
+        else
+          echo "ERROR: Chart version ($YAML_VERSION) differs from tag version ($TAG_VERSION)"
+          exit 1
+        fi
   only:
     - tags


### PR DESCRIPTION
1. Pushes only the chart whose name matches the tag (e.g., 'swan@0.0.5')
2. Makes sure the version in <chart_name>/Chart.yaml matches the tag version