### PR TITLE
Update user image to v5.14.1

### DIFF
--- a/swan-cern/swan.dev.values.yaml
+++ b/swan-cern/swan.dev.values.yaml
@@ -1,10 +1,5 @@
 swan:
   jupyterhub:
-    singleuser:
-      image:
-        name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-        tag: "v5.9.0"
-        pullPolicy: Always
     hub:
       image:
         name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -64,7 +64,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-      tag: "v5.13.0"
+      tag: "v5.14.1"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
- Update the user image to v5.14.1 containing SparkConnector v2.1.0
  - Removes unused cdh jar loaded from EOS for spark.driver.extraClassPath
  - JupyterLab support for SparkConnector
 
- Remove the config from swan.dev.values.yaml (as it is the same as the parent chart)