### PR TITLE
Add configuration for hadoop-confext path

### DIFF
--- a/swan-cern/files/private/dev/hadoop_token.sh
+++ b/swan-cern/files/private/dev/hadoop_token.sh
@@ -9,4 +9,4 @@ if [[ ! -f "/hadoop-token-generator/hadoop.cred" ]]; then
 fi
 
 # in dev, one can provide already generated token instead of the proxy user keytab
-cat /srv/jupyterhub/private/hadoop.cred > "${TOKEN_FILE_PATH}"
+cat /hadoop-token-generator/hadoop.cred > "${TOKEN_FILE_PATH}"

--- a/swan-cern/files/private/prod/hadoop_token.sh
+++ b/swan-cern/files/private/prod/hadoop_token.sh
@@ -18,7 +18,8 @@ LCG_VIEW=/cvmfs/sft.cern.ch/lcg/views/LCG_94/x86_64-slc6-gcc62-opt
 export OVERRIDE_HADOOP_MAPRED_HOME="${LCG_VIEW}"
 
 source "${LCG_VIEW}/setup.sh"
-source /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/hadoop-swan-setconf.sh "${CLUSTER}"
+# HADOOP_CONF_HOME set from chart template
+source "${HADOOP_CONF_HOME}/hadoop-swan-setconf.sh" "${CLUSTER}"
 
 kinit -V -kt /hadoop-token-generator/hadoop.cred hswan@CERN.CH -c "${KRB5CCNAME}"
 

--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -245,11 +245,11 @@ class SwanSparkPodHookHandler(SwanPodHookHandlerProd):
         )
 
         # add spark config env
-
+        conf_home = get_config('custom.spark.configurationPath')
         if cluster == 'k8s':
-            spark_conf_script = '/cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/k8s-swan-setconf.sh'
+            spark_conf_script = f'{conf_home}/k8s-swan-setconf.sh'
         else:
-            spark_conf_script = '/cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/hadoop-swan-setconf.sh'
+            spark_conf_script = f'{conf_home}/hadoop-swan-setconf.sh'
 
         notebook_container.env = self._add_or_replace_by_name(
             notebook_container.env,

--- a/swan-cern/templates/hadoop-token-generator.yaml
+++ b/swan-cern/templates/hadoop-token-generator.yaml
@@ -30,6 +30,8 @@ spec:
             secretKeyRef:
               name: hub
               key: hub.services.hadoop-token-generator.apiToken
+        - name: HADOOP_CONF_HOME
+          value: {{ .Values.swan.jupyterhub.custom.spark.configurationPath }} 
 
         image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v1.0.0 
         imagePullPolicy: Always

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -204,7 +204,8 @@ swan:
         deployDaemonSet: *eosDeployDS
         deployCsiDriver: *eosDeployCSI
         useCsiDriver: *eosUseCSI
-
+      spark:
+        configurationPath: /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext
 swanCern:
   secrets:
     eos:


### PR DESCRIPTION
Make `/cvmfs/sft.cern.ch/lcg/etc/hadoop-confext` path configurable, now that we have `/cvmfs/sft.cern.ch/lcg/etc/hadoop-confext-qa` deployed from the qa branch of https://gitlab.cern.ch/db/hadoop-confext