### PR TITLE
Use cvmfs@0.0.5 with prefetcher functionalities

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -3,6 +3,30 @@ swan:
     deployDaemonSet: &cvmfsDeployDS true
     deployCsiDriver: &cvmfsDeployCSI false
     useCsiDriver: &cvmfsUseCSI false
+    prefetcher:
+      enabled: true
+      jobs:
+        cron_opennotebook_python2_ipy:
+          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+          minute: '*/15'
+        cron_opennotebook_python2_root:
+          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+          minute: '*/15'
+        cron_opennotebook_python3_root:
+          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+          minute: '*/15'
+        cron_opennotebook_python3nx_ipy:
+          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3_nxcals/x86_64-centos7-gcc7-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+          minute: '*/15'
+        cron_opennotebook_python3nx_spark:
+          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true )"
+          minute: '*/15'
+        cron_opennotebook_cuda_tensorflow:
+          command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import tensorflow' > /dev/null 2>&1 || true )"
+          minute: '5,20,35,50'
+        cron_opennoteook_cuda_torch:
+          command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import torch' > /dev/null 2>&1 || true )"
+          minute: '10,25,40,55'
   eos:
     deployDaemonSet: &eosDeployDS false
     deployCsiDriver: &eosDeployCSI true

--- a/swan/Chart.lock
+++ b/swan/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 0.3.1
 - name: cvmfs
   repository: https://registry.cern.ch/chartrepo/sciencebox
-  version: 0.0.4
+  version: 0.0.5
 - name: cvmfs-csi
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.0
-digest: sha256:b8c51c9df17635614483cc7a57c5b4936ff18cf2f3b830e6f8555cec7c1eff68
-generated: "2022-01-07T10:40:34.001728425+01:00"
+digest: sha256:c7dc7437e90f98b5b0a60b46fd09d682ea03c0e51f94e4f71aa25bb470463a89
+generated: "2022-02-17T18:42:17.463481918+01:00"

--- a/swan/Chart.yaml
+++ b/swan/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     condition: eos.deployCsiDriver
 
   - name: cvmfs
-    version: 0.0.4
+    version: 0.0.5
     repository: https://registry.cern.ch/chartrepo/sciencebox
     condition: cvmfs.deployDaemonSet
   - name: cvmfs-csi

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -51,6 +51,12 @@ cvmfs:
       cron_opennotebook_python3nx_spark:
         command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true )"
         minute: '*/15'
+      cron_opennotebook_cuda_tensorflow:
+        command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import tensorflow' > /dev/null 2>&1 || true )"
+        minute: '5,20,35,50'
+      cron_opennoteook_cuda_torch:
+        command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import torch' > /dev/null 2>&1 || true )"
+        minute: '10,25,40,55'
 
 #
 # EOS access

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -33,30 +33,9 @@ cvmfs:
   prefetcher:
     enabled: true
     jobs:
-      cron_opennotebook_python2_ipy:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
-        minute: '*/15'
-      cron_opennotebook_python2_root:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
-        minute: '*/15'
       cron_opennotebook_python3_ipy:
         command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
         minute: '*/15'
-      cron_opennotebook_python3_root:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
-        minute: '*/15'
-      cron_opennotebook_python3nx_ipy:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3_nxcals/x86_64-centos7-gcc7-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
-        minute: '*/15'
-      cron_opennotebook_python3nx_spark:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true )"
-        minute: '*/15'
-      cron_opennotebook_cuda_tensorflow:
-        command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import tensorflow' > /dev/null 2>&1 || true )"
-        minute: '5,20,35,50'
-      cron_opennoteook_cuda_torch:
-        command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import torch' > /dev/null 2>&1 || true )"
-        minute: '10,25,40,55'
 
 #
 # EOS access

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -233,11 +233,6 @@ jupyterhub:
       users: true
       checkEosAuth: false
     cvmfs:
-      prefetcher:
-        enabled: false
-        image:
-          name: "gitlab-registry.cern.ch/swan/docker-images/cvmfs-prefetcher"
-          tag: "v1.1"
       deployDaemonSet: *cvmfsDeployDS
       deployCsiDriver: *cvmfsDeployCSI
       useCsiDriver: *cvmfsUseCSI

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -29,6 +29,28 @@ cvmfs:
     - sft-nightlies.cern.ch
   mountOptions:
     hostMountpoint: /var/cvmfs
+  # Prefetcher is provided only by the daemonSet
+  prefetcher:
+    enabled: true
+    jobs:
+      cron_opennotebook_python2_ipy:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+        minute: '*/15'
+      cron_opennotebook_python2_root:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+        minute: '*/15'
+      cron_opennotebook_python3_ipy:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+        minute: '*/15'
+      cron_opennotebook_python3_root:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+        minute: '*/15'
+      cron_opennotebook_python3nx_ipy:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3_nxcals/x86_64-centos7-gcc7-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+        minute: '*/15'
+      cron_opennotebook_python3nx_spark:
+        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true )"
+        minute: '*/15'
 
 #
 # EOS access


### PR DESCRIPTION
The CVMFS daemonSet now comes with prefetching functionality:
- There is a second container running in the daemonSet pod
- The container image is the same used by cvmfs main to avoid the overhead of pulling and storing a second image
- Such container runs crond, whose output goes to stdout (some debug flags are enabled)
- cronjobs are passed as configMap and can be set from values.yaml

Tested in ScienceBox:
```
# kubectl get pods 
NAME                                   READY   STATUS                  RESTARTS   AGE
hub-6f6c467cfc-7klmn                   1/1     Running                 0          19m
proxy-7cffc688b8-vmz4h                 1/1     Running                 0          19m
sciencebox-cvmfs-bk2z6                 2/2     Running                 0          19m
[...]

---
# kubectl describe pod sciencebox-cvmfs-bk2z6
[...
c]ontainers:
  cvmfs:
    Container ID:  docker://51c787401829878d3d36e12f91123ceb7cadebd5f451a79b9ad42a47e8db7dbd
    Image:         gitlab-registry.cern.ch/sciencebox/docker-images/cvmfs:2.9.0
[...]
  cvmfs-prefetcher:
    Container ID:  docker://51d7fcdc70e1cb33e1829f2fbce94a0b11d6b3bd8f2718011c567036c865ad56
    Image:         gitlab-registry.cern.ch/sciencebox/docker-images/cvmfs:2.9.0
    Image ID:      docker-pullable://gitlab-registry.cern.ch/sciencebox/docker-images/cvmfs@sha256:b2df4a6f3567746e55a918b0fcb6e0617c77e9d529b56f3dc9498e0668afc51d
    Port:          <none>
    Host Port:     <none>
    Command:
      /usr/sbin/crond
      -n
      -s
      -x
      ext,sch,proc,pars,misc,bit
```

Example of log produced by crond when running prefetch jobs:
```
log_it: (root 12) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3_nxcals/x86_64-centos7-gcc7-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true ))
log_it: (root 13) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true ))
log_it: (root 14) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true ))
log_it: (root 15) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true ))
log_it: (root 16) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true ))
log_it: (root 17) CMD (source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true ))
```

As of now, the prefetch jobs are copied from the production crontab.
The new CVMFS chart comes also with the latest-grated cvmfs version: 2.9.0
