### PR TITLE
Show EOS file versions

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -53,6 +53,13 @@ fusex:
   fusex:
     hostMountpoint: /var/eos
 
+# Ensure file versions are shown to allow notebook checkpoints
+# (the fusex chart already sets this as default)
+eosxd:
+  fuseconf:
+    options:
+      hide-versions: 0
+
 #
 # JupyerHub
 #


### PR DESCRIPTION
All other configs required to have EOS working with oAuth are set in the eosxd chart (https://gitlab.cern.ch/helm/charts/cern/-/merge_requests/78)