### PR TITLE
Update fusex chart to 0.1.2

### DIFF
--- a/swan/Chart.lock
+++ b/swan/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.2.0
 - name: fusex
   repository: https://registry.cern.ch/chartrepo/eos
-  version: 0.1.0
+  version: 0.1.2
 - name: eosxd
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.3.1
@@ -14,5 +14,5 @@ dependencies:
 - name: cvmfs-csi
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.0
-digest: sha256:c7dc7437e90f98b5b0a60b46fd09d682ea03c0e51f94e4f71aa25bb470463a89
-generated: "2022-02-17T18:42:17.463481918+01:00"
+digest: sha256:f5ea77e62573808ee9bc442a08f8991a51f28cb17f1d6b2ce62f42c91342f868
+generated: "2022-04-06T21:30:18.325958511+02:00"

--- a/swan/Chart.yaml
+++ b/swan/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     repository: https://jupyterhub.github.io/helm-chart/
 
   - name: fusex
-    version: 0.1.0
+    version: 0.1.2
     repository: https://registry.cern.ch/chartrepo/eos
     condition: eos.deployDaemonSet
   - name: eosxd


### PR DESCRIPTION
This is a dependency update for the fusex chart, i.e., the daemonSet implementation for ScienceBox.
My understanding is that this is not used for swan-cern prod (which instead uses the CSI driver), so nothing should break.

I used `qa` as base branch. Let me know if I should rebased against something else.