### PR TITLE
Remove service enviornment variables from user pods

### DIFF
--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -66,6 +66,9 @@ class SwanPodHookHandler:
                 ),
             )
 
+        # Disable adding environment variables from Kubernetes services in the same namespace
+        self.pod.spec.enable_service_links = False
+
         return self.pod
 
     def _gpu_enabled(self):


### PR DESCRIPTION
A large environment created by many kubernetes service objects causes timeouts in the EOS daemonset looking up the user environment for access tokens etc