### PR TITLE
Cleanup spark NodePort services

### DIFF
--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -347,7 +347,20 @@ def spark_modify_pod_hook(spawner, pod):
     spark_pod_hook_handler = SwanSparkPodHookHandler(spawner, pod)
     return spark_pod_hook_handler.get_swan_user_pod()
 
-# Get configuration parameters from environment variables
-# swan_container_namespace = os.environ.get('POD_NAMESPACE', 'default')
+
+def spark_cleanup_services(spawner):
+    """
+    :param spawner: Swan Kubernetes Spawner
+    :type spawner: swanspawner.SwanKubeSpawner
+    
+    """
+    spark_cluster = spawner.user_options[spawner.spark_cluster_field]
+    if spark_cluster and spark_cluster != 'none':
+        username = spawner.user.name
+        spark_ports_service = f"spark-ports-{username}"
+        spawner.log.info('Deleting service %s', spark_ports_service)
+        swan_container_namespace = os.environ.get('POD_NAMESPACE', 'default')
+        spawner.api.delete_namespaced_service(spark_ports_service, swan_container_namespace)
 
 c.SwanKubeSpawner.modify_pod_hook = spark_modify_pod_hook
+c.SwanKubeSpawner.post_stop_hook = spark_cleanup_services


### PR DESCRIPTION
- To allow spark/dask workers to reach the driver running in a user pod from outside the cluster, we open ports using `type: NodePort` services

- We have a limited number of ports available for `type: NodePort` kubernetes services. The available range is specified through the `--service-node-port-range` [flag](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) (default: 30000-32767) when creating the cluster. This currently only support ~150 users with 18 ports open for each user session/pod.

This change cleans up these services when the spawner stops the user server, to prevent them from accumulating over time.

Related: #64 fixed issues caused by too many environment variables due to many services in the namespace, causing timeouts in EOS daemon trying to read the environment for auth tokens.
