### PR TITLE
Add LCG 102 to options form

### DIFF
--- a/swan-cern/options_form_config.json
+++ b/swan-cern/options_form_config.json
@@ -11,69 +11,14 @@
         {
             "type": "selection",
             "lcg": {
-                "value": "LCG_101swan",
-                "text": "101"
+                "value": "LCG_102swan",
+                "text": "102"
             },
             "platforms": [
                 {
-                    "value": "x86_64-centos7-gcc8-opt",
-                    "text": "CentOS 7 (gcc8)"
+                    "value": "x86_64-centos7-gcc11-opt",
+                    "text": "CentOS 7 (gcc11)"
                 },
-                {
-                    "value": "x86_64-centos7-gcc10-opt",
-                    "text": "CentOS 7 (gcc10)"
-                }
-            ],
-            "cores": [
-                {
-                    "value": "2",
-                    "text": "2"
-                },
-                {
-                    "value": "4",
-                    "text": "4"
-                }
-            ],
-            "memory": [
-                {
-                    "value": "8",
-                    "text": "8 GB"
-                },
-                {
-                    "value": "10",
-                    "text": "10 GB"
-                },
-                {
-                    "value": "16",
-                    "text": "16 GB"
-                }
-            ],
-            "clusters": [
-                {
-                    "value": "none",
-                    "text": "None"
-                },
-                {
-                    "value": "analytix",
-                    "text": "General Purpose (Analytix)"
-                },
-                {
-                    "value": "k8s",
-                    "text": "Cloud Containers (K8s)"
-                },
-                {
-                    "value": "hadoop-qa",
-                    "text": "QA"
-                }
-            ]
-        },
-        {
-            "type": "selection",
-            "lcg": {
-                "value": "LCG_99python2",
-                "text": "99 Python2"
-            },
-            "platforms": [
                 {
                     "value": "x86_64-centos7-gcc8-opt",
                     "text": "CentOS 7 (gcc8)"
@@ -212,37 +157,37 @@
                 }
             ]
         },
-    {
-        "type": "selection",
-        "lcg": {
-            "value": "LCG_101cuda",
-            "text": "101 Cuda 11.2 (GPU)"
+        {
+            "type": "selection",
+            "lcg": {
+                "value": "LCG_102cuda",
+                "text": "102 Cuda 11.2 (GPU)"
+            },
+            "platforms": [
+                {
+                    "value": "x86_64-centos7-gcc8-opt",
+                    "text": "CentOS 7 (gcc8)"
+                }
+            ],
+            "cores": [
+                {
+                    "value": "2",
+                    "text": "2CPU, 1GPU"
+                }
+            ],
+            "memory": [
+                {
+                    "value": "16",
+                    "text": "16 GB"
+                }
+            ],
+            "clusters": [
+                {
+                    "value": "none",
+                    "text": "None"
+                }
+            ]
         },
-        "platforms": [
-            {
-                "value": "x86_64-centos7-gcc8-opt",
-                "text": "CentOS 7 (gcc8)"
-            }
-        ],
-        "cores": [
-            {
-                "value": "2",
-                "text": "2CPU, 1GPU"
-            }
-        ],
-        "memory": [
-            {
-                "value": "16",
-                "text": "16 GB"
-            }
-        ],
-        "clusters": [
-            {
-                "value": "none",
-                "text": "None"
-            }
-        ]
-    },
         {
             "type": "label",
             "label": {
@@ -430,6 +375,96 @@
         {
             "type": "selection",
             "lcg": {
+                "value": "LCG_101swan",
+                "text": "101"
+            },
+            "platforms": [
+                {
+                    "value": "x86_64-centos7-gcc8-opt",
+                    "text": "CentOS 7 (gcc8)"
+                },
+                {
+                    "value": "x86_64-centos7-gcc10-opt",
+                    "text": "CentOS 7 (gcc10)"
+                }
+            ],
+            "cores": [
+                {
+                    "value": "2",
+                    "text": "2"
+                },
+                {
+                    "value": "4",
+                    "text": "4"
+                }
+            ],
+            "memory": [
+                {
+                    "value": "8",
+                    "text": "8 GB"
+                },
+                {
+                    "value": "10",
+                    "text": "10 GB"
+                },
+                {
+                    "value": "16",
+                    "text": "16 GB"
+                }
+            ],
+            "clusters": [
+                {
+                    "value": "none",
+                    "text": "None"
+                },
+                {
+                    "value": "analytix",
+                    "text": "General Purpose (Analytix)"
+                },
+                {
+                    "value": "k8s",
+                    "text": "Cloud Containers (K8s)"
+                },
+                {
+                    "value": "hadoop-qa",
+                    "text": "QA"
+                }
+            ]
+        },
+        {
+            "type": "selection",
+            "lcg": {
+                "value": "LCG_101cuda",
+                "text": "101 Cuda 11.2 (GPU)"
+            },
+            "platforms": [
+                {
+                    "value": "x86_64-centos7-gcc8-opt",
+                    "text": "CentOS 7 (gcc8)"
+                }
+            ],
+            "cores": [
+                {
+                    "value": "2",
+                    "text": "2CPU, 1GPU"
+                }
+            ],
+            "memory": [
+                {
+                    "value": "16",
+                    "text": "16 GB"
+                }
+            ],
+            "clusters": [
+                {
+                    "value": "none",
+                    "text": "None"
+                }
+            ]
+        },
+        {
+            "type": "selection",
+            "lcg": {
                 "value": "LCG_100",
                 "text": "100"
             },
@@ -573,6 +608,61 @@
                 {
                     "value": "none",
                     "text": "None"
+                }
+            ]
+        },
+        {
+            "type": "selection",
+            "lcg": {
+                "value": "LCG_99python2",
+                "text": "99 Python2"
+            },
+            "platforms": [
+                {
+                    "value": "x86_64-centos7-gcc8-opt",
+                    "text": "CentOS 7 (gcc8)"
+                }
+            ],
+            "cores": [
+                {
+                    "value": "2",
+                    "text": "2"
+                },
+                {
+                    "value": "4",
+                    "text": "4"
+                }
+            ],
+            "memory": [
+                {
+                    "value": "8",
+                    "text": "8 GB"
+                },
+                {
+                    "value": "10",
+                    "text": "10 GB"
+                },
+                {
+                    "value": "16",
+                    "text": "16 GB"
+                }
+            ],
+            "clusters": [
+                {
+                    "value": "none",
+                    "text": "None"
+                },
+                {
+                    "value": "analytix",
+                    "text": "General Purpose (Analytix)"
+                },
+                {
+                    "value": "k8s",
+                    "text": "Cloud Containers (K8s)"
+                },
+                {
+                    "value": "hadoop-qa",
+                    "text": "QA"
                 }
             ]
         },


### PR DESCRIPTION
- Add 102swan and 102cuda in recommended releases
- Make gcc 11 the default compiler version for LCG 102
- Move 99 python2 and 101 to other releases

---
Before:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/6822941/179712101-b43ae947-e150-4812-85f9-a2b18b0e46f3.png">

After:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/6822941/179712037-8aa5d23a-8f6b-4937-a235-382d38e7f6ef.png">
