### PR TITLE
Fix HDFSBrowser missing webhdfs token

### DIFF
--- a/swan-cern/files/private/prod/webhdfs_token.sh
+++ b/swan-cern/files/private/prod/webhdfs_token.sh
@@ -8,6 +8,7 @@ elif [ "$1" == "hadoop-qa" ]; then HDFSNAMESPACE='hdpqa'
 else HDFSNAMESPACE=$1
 fi
 NAMENODES=$(xmllint --xpath '/configuration//property[name="dfs.ha.namenodes.'"$HDFSNAMESPACE"'"]/value/text()' /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/conf/etc/$1/hadoop.$1/hdfs-site.xml)
+echo "$NAMENODES"
 }
 
 CLUSTER=$1


### PR DESCRIPTION
As function `get_namenodes` runs in a subshell (in `$()`) we need to explicitly write `NAMENODES` to stdout