### PR TITLE
Bump jupyterhub image to v1.23

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -130,7 +130,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v1.22"
+      tag: "v1.23"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
This new image has the improved version of the keycloakauthenticator (`3.1.1`), which support self-signed (or invalid) certificates.