### PR TITLE
Enable CERN HTCondor configuration flag

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -172,7 +172,10 @@ swan:
           # skip refreshing tokens if already refreshed in last 15 minutes
           # this assumes tokens provided by keycloak are valid for 20 minutes
           auth_refresh_age: 900
-          
+        SwanSpawner:
+          environment: 
+            # Enable HTCondor service configuration for CERN the in user image
+            CERN_HTCONDOR: "true"
         JupyterHub:
           allow_named_servers: False
       extraConfig:


### PR DESCRIPTION
- Aligns with puppet nodes to create `/etc/condor` from the batch service configuration
- Sets the environment variable to toggle the [flag](https://github.com/swan-cern/systemuser-image/blob/effdb9edb0262ba75ff94e19b914049460dd3e92/systemuser.sh#L216) in the image. 

