### PR TITLE
Enable Liveness Probe for Hub Pod

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -125,7 +125,11 @@ jupyterhub:
         cpu: 200m
         memory: 512Mi
     livenessProbe:
-      enabled: false
+      enabled: true
+      initialDelaySeconds: 300
+      periodSeconds: 15
+      failureThreshold: 20
+      timeoutSeconds: 10
     readinessProbe:
       enabled: false
     image:


### PR DESCRIPTION
- Waits for 5 minutes for hub to start up.
- Restarts hub container if probe fails for 20 * 15 = 5 minutes


- I have increased the timeouts from the [upstream defaults](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/5c0d0c5c74bc97bf403844ced6b8e79cc089498d/jupyterhub/values.yaml#L118) (adjusting other values to restart in 5 minutes) to ensure we don't restart the hub unless it is really stuck.