### PR TITLE
Fix EOS Kerberos Auth failing due to large KRB5CC

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -62,6 +62,9 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
             secret_meta = client.V1ObjectMeta()
             secret_meta.name = eos_secret_name
             secret_meta.namespace = swan_container_namespace
+            secret_meta.labels = {
+                "swan_user": username
+            }
             secret_data.metadata = secret_meta
             secret_data.data = {}
             secret_data.data['krb5cc'] = eos_token_base64


### PR DESCRIPTION
The size of the kerberos credentials cache is large for some users.
The curl command to replace the secret fails because the arguments are too long. So instead this passes the JSON body as a file

- Also adds a `swan_user: ` label to the secret aligning with the pod labels