### PR TITLE
Reorganize cron jobs for warming up CVMFS cache

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -6,27 +6,27 @@ swan:
     prefetcher:
       enabled: true
       jobs:
-        cron_opennotebook_python2_ipy:
-          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+        # ROOT
+        cron_opennotebook_root_kernel:
+          command: >-
+            source /cvmfs/sft.cern.ch/lcg/views/LCG_102swan/x86_64-centos7-gcc11-opt/setup.sh &&
+            (timeout 20s python3 -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true)
           minute: '*/15'
-        cron_opennotebook_python2_root:
-          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_99python2/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+        # NXCALS
+        cron_opennotebook_nxcals:
+          command: >-
+            source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh &&
+            (timeout 20s python3 -m ipykernel > /dev/null 2>&1 || true) &&
+            (timeout 20s python3 -c 'import pyspark' || true)
           minute: '*/15'
-        cron_opennotebook_python3_root:
-          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true )"
+        # CUDA
+        cron_opennotebook_cuda:
+          command: >-
+            (lsmod | grep nvidia) &&
+            source /cvmfs/sft.cern.ch/lcg/views/LCG_102cuda/x86_64-centos7-gcc8-opt/setup.sh &&
+            (timeout 20s python3 -c 'import tensorflow' || true) &&
+            (timeout 20s python3 -c 'import torch' || true)
           minute: '*/15'
-        cron_opennotebook_python3nx_ipy:
-          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_95apython3_nxcals/x86_64-centos7-gcc7-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
-          minute: '*/15'
-        cron_opennotebook_python3nx_spark:
-          command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_100_nxcals/x86_64-centos7-gcc9-opt/setup.sh && ( timeout 20s python -c 'import pyspark' > /dev/null 2>&1 || true )"
-          minute: '*/15'
-        cron_opennotebook_cuda_tensorflow:
-          command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import tensorflow' > /dev/null 2>&1 || true )"
-          minute: '5,20,35,50'
-        cron_opennoteook_cuda_torch:
-          command: "(lsmod | grep nvidia) && source /cvmfs/sft.cern.ch/lcg/views/LCG_101cuda/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 60s python -c 'import torch' > /dev/null 2>&1 || true )"
-          minute: '10,25,40,55'
   eos:
     deployDaemonSet: &eosDeployDS false
     deployCsiDriver: &eosDeployCSI true

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -33,8 +33,11 @@ cvmfs:
   prefetcher:
     enabled: true
     jobs:
-      cron_opennotebook_python3_ipy:
-        command: "source /cvmfs/sft.cern.ch/lcg/views/LCG_101swan/x86_64-centos7-gcc8-opt/setup.sh && ( timeout 20s python -m ipykernel > /dev/null 2>&1 || true )"
+      # Python3 kernel
+      cron_opennotebook_python3_kernel:
+        command: >-
+          source /cvmfs/sft.cern.ch/lcg/views/LCG_102swan/x86_64-centos7-gcc11-opt/setup.sh &&
+          (timeout 20s python3 -m ipykernel > /dev/null 2>&1 || true)
         minute: '*/15'
 
 #


### PR DESCRIPTION
- Updates the LCG release numbers to the latest that are currently in production.
- Removes warming up of Spark2 stack, since it is not used as much as the other stacks (SWAN, NXCALS, CUDA)
- Configures the swan chart to define the LCG_102swan cron job for the Python kernel, while the swan-cern chart takes care of LCG102_swan for the ROOT kernel, the NXCALS and the CUDA stacks.
- Fixes an issue with the Pytorch package (its name in Python is torch, not pytorch).
- Fuses the import of tensorflow and torch in a single cron job.
- Removes the setting of specific minutes in which the warming up of the CUDA stack happens. Running it every 15 minutes like the rest of the stacks should be good enough.
- Removes the redirection to /dev/null when importing packages, so we can find those errors in the CVMFS container logs. The output when starting kernels is still discarded, since it would pollute the logs.
- Sets all command timeouts to 20s.