### PR TITLE
Remote annotation to restart Hub by default on any deployment

### DIFF
--- a/utils/deploy_k8s.sh
+++ b/utils/deploy_k8s.sh
@@ -82,7 +82,6 @@ echo ""
 helm upgrade --install --namespace swan  \
 --kubeconfig $KUBECONFIG \
 --values $SWAN_SECRET_VALUES_PATH \
---set swan.jupyterhub.hub.annotations.version="release-$(date +%s)" \
 --set swan.jupyterhub.hub.db.upgrade=$UPGRADE_DB \
 --set swanCern.secrets.hadoop.cred=$HADOOP_AUTH_KEYTAB_ENCODED \
 --set swanCern.secrets.eos.cred=$EOS_AUTH_KEYTAB_ENCODED \


### PR DESCRIPTION
Sometimes the changes do not justify that the hub is restarted, for example when changing cvmfs-prefetcher cron job rules.