### PR TITLE
Replace default-logs-container annotation (deprecated) by default-con…

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -94,7 +94,7 @@ jupyterhub:
     networkPolicy:
       enabled: false
     extraAnnotations:
-      kubectl.kubernetes.io/default-logs-container: notebook
+      kubectl.kubernetes.io/default-container: notebook
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
…tainer:

https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

This works for both kubectl logs and kubectl exec.