### PR TITLE
Upgrade Hub image to v1.28

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -139,7 +139,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v1.26"
+      tag: "v1.28"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
https://github.com/swan-cern/jupyterhub-image/releases/tag/v1.28