### PR TITLE
Disable request to hub for Maintenance Notifications

### DIFF
--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -32,17 +32,6 @@ class SwanPodHookHandler:
         # init pod affinity
         self.pod.spec.affinity = self._init_pod_affinity(pod_labels)
 
-        notebook_container = self._get_pod_container('notebook')
-
-        # Disable pinging for maintenance notifications when running on Kubernetes
-        notebook_container.env = self._add_or_replace_by_name(
-            notebook_container.env,
-            client.V1EnvVar(
-                name='SWAN_DISABLE_NOTIFICATIONS',
-                value='true'
-            ),
-        )
-
         if self._gpu_enabled():
             # currently no cern customisation required
             self.pod.spec.volumes.append(
@@ -51,6 +40,8 @@ class SwanPodHookHandler:
                     name='nvidia-driver'
                 )
             )
+
+            notebook_container = self._get_pod_container('notebook')
 
             notebook_container.volume_mounts.append(
                 client.V1VolumeMount(

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -32,6 +32,17 @@ class SwanPodHookHandler:
         # init pod affinity
         self.pod.spec.affinity = self._init_pod_affinity(pod_labels)
 
+        notebook_container = self._get_pod_container('notebook')
+
+        # Disable pinging for maintenance notifications when running on Kubernetes
+        notebook_container.env = self._add_or_replace_by_name(
+            notebook_container.env,
+            client.V1EnvVar(
+                name='SWAN_DISABLE_NOTIFICATIONS',
+                value='true'
+            ),
+        )
+
         if self._gpu_enabled():
             # currently no cern customisation required
             self.pod.spec.volumes.append(
@@ -40,8 +51,6 @@ class SwanPodHookHandler:
                     name='nvidia-driver'
                 )
             )
-
-            notebook_container = self._get_pod_container('notebook')
 
             notebook_container.volume_mounts.append(
                 client.V1VolumeMount(

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -95,6 +95,8 @@ jupyterhub:
       enabled: false
     extraAnnotations:
       kubectl.kubernetes.io/default-container: notebook
+    extraEnv:
+      SWAN_DISABLE_NOTIFICATIONS: "true"
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
When running on Kubernetes we do not take nodes offline with /etc/nologin, and this mechanism is broken in the Kubernetes setup. Browser pages make a request every 60s to ping for notifications to the hub. Disabling this also reduces the load on the hub pod.

Works together with https://github.com/swan-cern/systemuser-image/pull/93