### PR TITLE
Clean Up Fluentd Configuration

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -314,266 +314,124 @@ fluentd:
     - fluent-plugin-rewrite-tag-filter
     - fluent-plugin-out-http
     - fluent-plugin-grok-parser
-    - fluent-plugin-concat
   output:
     producer: swan
     endpoint: http://monit-logs.cern.ch:10012/
     includeInternal: false
   parsingConfig: |
-    ### Define Classes of logs ###
-
     <match kubernetes.**>
-      @type rewrite_tag_filter
-      capitalize_regex_backreference true
-      # jupyter notebook logs
-      <rule>
-        key $.kubernetes.pod_name
-        pattern ^(jupyter-|hub-|proxy-|cvmfs-prefetcher-)
-        tag swan
-      </rule>
-      <rule>
-        key $.kubernetes.pod_name
-        pattern (.?)
-        tag system
-      </rule>
-    </match>
-    <match {swan}>
-      @type rewrite_tag_filter
-      capitalize_regex_backreference true
-      # jupyter or jupyterhub custom swan metrics
-      <rule>
-        key $.log
-        pattern (^.*?user: .*?, host: .*?, metric: .*?, value: .*$)
-        tag swan.metrics
-      </rule>
-      <rule>
-        key $.log
-        pattern (.?)
-        tag swan.logs
-      </rule>
+        @type rewrite_tag_filter
+        capitalize_regex_backreference true
+        <rule>
+            key $.kubernetes.labels.component
+            pattern /^singleuser-server$/
+            tag user # user logs + metrics
+        </rule>
+        <rule>
+            key $.kubernetes.labels.component
+            pattern /^hub$/
+            tag hub # hub logs + metrics
+        </rule>
+        <rule>
+            key $.kubernetes.pod_name
+            pattern /.?/
+            tag logs 
+        </rule>
     </match>
 
-    ### SWAN Jupyter/Jupyterhub logs parsing and output ###
-
-    # jupyter containers parser
-    <filter {swan.logs}>
-      @type concat
-      key log
-
-      # parse jupyterhub multiline debug log with indent
-      stream_identity_key docker.container_id
-      multiline_start_regexp /^(\[.*\] pod \w+/jupyter-\w+ events before launch)/
-      continuous_line_regexp /^(\s).*\[/
-      flush_interval 1
-      separator "\n"
-      timeout_label @swan.logs.multiline
-    </filter>
-    <filter {swan.logs}>
-      @type concat
-      key log
-
-      # parse python multiline error logs with indent
-      # handle also timeout waiting for new log lines
-      stream_identity_key docker.container_id
-      multiline_start_regexp /^(\[.*\] E)/
-      continuous_line_regexp /^(\s)/
-      separator "\n"
-      flush_interval 1
-      timeout_label @swan.logs.multiline
-    </filter>
-    <match {swan.logs}>
-      @type relabel
-      @label @swan.logs.multiline
+    <match {user,hub}>
+        @type rewrite_tag_filter
+        capitalize_regex_backreference true
+        # jupyter or jupyterhub custom swan metrics
+        <rule>
+            key $.log
+            pattern /^.*?user: .*?, host: .*?, metric: .*?, value: .*$/
+            tag metrics
+        </rule>
+        <rule>
+            key $.log
+            pattern /.?/
+            tag logs
+        </rule>
     </match>
-    <label @swan.logs.multiline>
-      # all logs that were parsed with multiline concat filter or got timeout waiting for new logs to parse multiline
 
-      <filter {swan.logs}>
+    ### SWAN Metrics logs parsing and output ###
+
+    <filter {metrics}>
         @type parser
         key_name log
 
-        # keep original record data additionaly to parsed one
         reserve_data true
         emit_invalid_record_to_error true
 
         # grok parsing
         <parse>
-          @type grok
+            @type grok
 
-          # keep unmatched logs
-          grok_success_key grok_success
-          grok_failure_key grok_failure
+            # keep unmatched logs
+            grok_failure_key grokfailure
 
-          <grok>
-            # jupyterhub hub message (including multiline)
-            pattern \[%{WORD:log_level} %{TIMESTAMP_ISO8601:log_time} %{DATA:log_source}\] (?<log_msg_multiline>(.|\r|\n)*)
-            time_format "%Y-%m-%d %H:%M:%S.%N"
-            keep_time_key false
-            time_key log_time
-            timezone +0100
-          </grok>
-
-          <grok>
-            # jupyterhub culler message (including multiline)
-            pattern \[%{WORD:log_level} (?<log_time>%{YEAR}%{MONTHNUM}%{MONTHDAY} %{TIME}) %{DATA:log_source}\] (?<log_msg_multiline>(.|\r|\n)*)
-            time_format "%y%m%d %H:%M:%S"
-            keep_time_key false
-            time_key log_time
-            timezone +0100
-          </grok>
-
-          <grok>
-            # jupyterhub proxy message (including multiline)
-            pattern (?<log_time>%{TIME}.%{DATA}) \[%{DATA:log_source}\] (.*?)(?<log_level>(debug|info|error|warn|critical))([^$]*): (?<log_msg_multiline>(.|\r|\n)*)
-            time_format "%H:%M:%S.%N"
-            keep_time_key false
-            time_key log_time
-            timezone +0000
-          </grok>
-
-          <grok>
-            # jupyterhub generic message (including multiline)
-            pattern (?<log_msg_multiline>(.|\r|\n)*)
-          </grok>
+            <grok>
+                # messages printed with "metric: metric_key.metric_context", where metric_context can have dots
+                pattern user: %{DATA:_metric_user_}, host: %{DATA}, metric: (?<_metric_key_>(\w*))(\.)(?<_metric_context_>(.*)), value: %{GREEDYDATA:_metric_value_}
+            </grok>
+            <grok>
+                # messages printed with "metric: metric_key"
+                pattern user: %{DATA:_metric_user_}, host: %{DATA}, metric: (?<_metric_key_>(.*))(?<_metric_context_>(.*)), value: %{GREEDYDATA:_metric_value_}
+            </grok>
         </parse>
-      </filter>
-      <filter {swan.logs}>
+    </filter>
+
+    <filter {metrics}>
         @type record_transformer
         enable_ruby
         <record>
-          # es wont search in string longer than 256
-          log_msg ${if record['log_msg_multiline'].length >= 250; record['log_msg_multiline'][0...250] + "..."; else; record['log_msg_multiline']; end;}
-          log_source ${if record['log_source'] != nil; record['log_source']; else; "log"; end;}
-          log_level ${if record['log_level'] != nil; record['log_level']; else; "info"; end;}
-          timestamp ${(time.to_f * 1000).to_i}
+            metrics.${record['_metric_key_']}.user ${record['_metric_user_']}
+            metrics.${record['_metric_key_']}.context ${record['_metric_context_']}
+            metrics.${record['_metric_key_']}.value ${record['_metric_value_']}
+        </record>
+        remove_keys ["_metric_user_", "_metric_key_", "_metric_context_", "_metric_value_"]
+    </filter>
 
-          # define monit producer
-          producer "#{ENV['OUTPUT_PRODUCER']}"
-          type "swanqa"
+
+    <filter {logs}>
+        @type record_transformer
+        <record>
+            type "logs"
+        </record>
+    </filter>
+
+    <filter {metrics}>
+        @type record_transformer
+        <record>
+            type "metrics"
+        </record>
+    </filter>
+
+    <filter {logs,metrics}>
+        @type record_transformer
+        enable_ruby
+        <record>
+            timestamp ${(time.to_f * 1000).to_i}
+            # define monit producer
+            producer "#{ENV['OUTPUT_PRODUCER']}"
+            raw ${record["log"]} # field named raw is indexed by MONIT/ES
         </record>
         remove_keys ["log"]
-      </filter>
-      <match {swan.logs}>
+    </filter>
+
+    <match {logs,metrics}>
         @type http
         endpoint_url    "#{ENV['OUTPUT_ENDPOINT']}"
         serializer      json
         http_method     post
-      </match>
-    </label>
-
-    ### SWAN Metrics logs parsing and output ###
-
-    # parse jupyter and jupyterhub metrics
-    <filter {swan.metrics}>
-      @type parser
-      key_name log
-
-      reserve_data true
-      emit_invalid_record_to_error true
-
-      # grok parsing
-      <parse>
-        @type grok
-
-        # keep unmatched logs
-        grok_failure_key grokfailure
-
-        <grok>
-          pattern \[%{WORD} %{TIMESTAMP_ISO8601:log_time} %{DATA}\] %{GREEDYDATA:log_msg}
-          time_format "%Y-%m-%d %H:%M:%S.%N"
-          keep_time_key false
-          time_key log_time
-          timezone +0100
-        </grok>
-      </parse>
-    </filter>
-    <filter {swan.metrics}>
-      @type parser
-      key_name log_msg
-
-      reserve_data true
-      emit_invalid_record_to_error true
-
-      # grok parsing
-      <parse>
-        @type grok
-
-        # keep unmatched logs
-        grok_failure_key grokfailure
-
-        <grok>
-          # string type metric_key.metric_context.metric_type
-          pattern user: %{DATA:_metric_user_}, host: %{DATA}, metric: (?<_metric_key_>(\w*))(\.)(?<_metric_context_>(.*)), value: %{GREEDYDATA:_metric_value_}
-          time_format "%Y-%m-%d %H:%M:%S.%N"
-          keep_time_key false
-          time_key metric_time
-          timezone +0100
-        </grok>
-        <grok>
-          # string type metric_key
-          pattern user: %{DATA:_metric_user_}, host: %{DATA}, metric: (?<_metric_key_>(.*))(?<_metric_context_>(.*)), value: %{GREEDYDATA:_metric_value_}
-          time_format "%Y-%m-%d %H:%M:%S.%N"
-          keep_time_key false
-          time_key metric_time
-          timezone +0100
-        </grok>
-      </parse>
-    </filter>
-    <filter {swan.metrics}>
-      @type record_transformer
-      enable_ruby
-      <record>
-        metrics.${record['_metric_key_']}.user ${record['_metric_user_']}
-        metrics.${record['_metric_key_']}.context ${record['_metric_context_']}
-        metrics.${record['_metric_key_']}.value ${record['_metric_value_']}
-        #the gsub is needed to match the indexes in ES, the split [-1] to remove lcg version from exception message
-        metric.${record['_metric_key_']}_${record['_metric_context_'].gsub('-','_').split('.')[-1]} ${record['_metric_value_']}
-      </record>
-      remove_keys ["_metric_time_", "_metric_raw_msg_", "_metric_user_", "_metric_key_", "_metric_context_", "_metric_value_"]
-    </filter>
-    <filter {swan.metrics}>
-      @type record_transformer
-      enable_ruby
-      <record>
-        producer "#{ENV['OUTPUT_PRODUCER']}"
-        type "metricsqa"
-        timestamp ${(time.to_f * 1000).to_i}
-      </record>
-      remove_keys ["log"]
-    </filter>
-    <match {swan.metrics}>
-      @type http
-      endpoint_url    "#{ENV['OUTPUT_ENDPOINT']}"
-      serializer      json
-      http_method     post
     </match>
-
-    ### System logs parsing and output ###
-
-    <filter {system}>
-      @type record_transformer
-      enable_ruby
-      <record>
-        producer "#{ENV['OUTPUT_PRODUCER']}"
-        type "system"
-        timestamp ${time.to_i * 1000}
-        log_msg ${record['log'].strip}
-      </record>
-      remove_keys ["log"]
-    </filter>
-    <match {system}>
-      @type http
-      endpoint_url    "#{ENV['OUTPUT_ENDPOINT']}"
-      serializer      json
-      http_method     post
-    </match>
-
 
     ### Common error handling ###
 
     # rescue errors to fluentd pod stdout for debugging
     <label @ERROR>
-      <match **>
-        @type stdout
-      </match>
+        <match **>
+            @type stdout
+        </match>
     </label>

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -319,18 +319,22 @@ fluentd:
     endpoint: http://monit-logs.cern.ch:10012/
     includeInternal: false
   parsingConfig: |
+    # Initial tagging of logs:
+    # - user: user session pods
+    # - hub: hub pod
+    # - logs: other pods
     <match kubernetes.**>
         @type rewrite_tag_filter
         capitalize_regex_backreference true
         <rule>
             key $.kubernetes.labels.component
             pattern /^singleuser-server$/
-            tag user # user logs + metrics
+            tag user
         </rule>
         <rule>
             key $.kubernetes.labels.component
             pattern /^hub$/
-            tag hub # hub logs + metrics
+            tag hub
         </rule>
         <rule>
             key $.kubernetes.pod_name
@@ -339,10 +343,12 @@ fluentd:
         </rule>
     </match>
 
+    # Retag user and hub logs to:
+    # - metrics: jupyter and jupyterhub custom log messages, used to emit metrics
+    # - logs: rest of log messages
     <match {user,hub}>
         @type rewrite_tag_filter
         capitalize_regex_backreference true
-        # jupyter or jupyterhub custom swan metrics
         <rule>
             key $.log
             pattern /^.*?user: .*?, host: .*?, metric: .*?, value: .*$/
@@ -355,8 +361,12 @@ fluentd:
         </rule>
     </match>
 
-    ### SWAN Metrics logs parsing and output ###
-
+    # Extract relevant information from metric logs:
+    # - user
+    # - host
+    # - metric key: name of the metric
+    # - metric context (optional): additional qualifiers for the metric
+    # - metric value
     <filter {metrics}>
         @type parser
         key_name log
@@ -364,7 +374,6 @@ fluentd:
         reserve_data true
         emit_invalid_record_to_error true
 
-        # grok parsing
         <parse>
             @type grok
 
@@ -382,6 +391,9 @@ fluentd:
         </parse>
     </filter>
 
+    # Store extracted metric information in a new "metrics" field, as part of the JSON
+    # of the log message. Use metric key as first attribute under "metrics".
+    # Format: metrics.metric_key.user|context|value
     <filter {metrics}>
         @type record_transformer
         enable_ruby
@@ -393,7 +405,8 @@ fluentd:
         remove_keys ["_metric_user_", "_metric_key_", "_metric_context_", "_metric_value_"]
     </filter>
 
-
+    # Emit general log records with type "logs"
+    # Accessible in OpenSearch with pattern monit_private_swan_logs_logs
     <filter {logs}>
         @type record_transformer
         <record>
@@ -401,6 +414,8 @@ fluentd:
         </record>
     </filter>
 
+    # Emit metric log records with type "metrics"
+    # Accessible in OpenSearch with pattern monit_private_swan_logs_metrics
     <filter {metrics}>
         @type record_transformer
         <record>
@@ -408,18 +423,20 @@ fluentd:
         </record>
     </filter>
 
+    # Set MONIT producer for all logs
+    # Keep raw log data in "raw" field
     <filter {logs,metrics}>
         @type record_transformer
         enable_ruby
         <record>
             timestamp ${(time.to_f * 1000).to_i}
-            # define monit producer
             producer "#{ENV['OUTPUT_PRODUCER']}"
-            raw ${record["log"]} # field named raw is indexed by MONIT/ES
+            raw ${record["log"]} # field named raw is indexed by MONIT/OpenSearch
         </record>
         remove_keys ["log"]
     </filter>
 
+    # Push logs to MONIT endpoint
     <match {logs,metrics}>
         @type http
         endpoint_url    "#{ENV['OUTPUT_ENDPOINT']}"
@@ -427,9 +444,7 @@ fluentd:
         http_method     post
     </match>
 
-    ### Common error handling ###
-
-    # rescue errors to fluentd pod stdout for debugging
+    # Forward errors in this pipeline to fluentd pod stdout for debugging
     <label @ERROR>
         <match **>
             @type stdout


### PR DESCRIPTION
- Always use the timestamp from containerd, instead of parsing the time in the log
- Remove multiline concatenation
- Simplify index names, with two indexes `logs`, `metrics` (passed as data.type) to monit
- Simplify the pipeline by avoiding duplicate filters, and refactor tagging between filters
- Remove parsing log_level, log_source and other unnecessary fields not used from kibana