### PR TITLE
Update interval that authenticator skips refreshing between refresh_user calls

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -196,9 +196,9 @@ swan:
           client_secret: # placeholder, check secrets
           oauth_callback_url: # placeholder, check secrets
 
-          # skip refreshing tokens if already refreshed in last 15 minutes
-          # this assumes tokens provided by keycloak are valid for 20 minutes
-          auth_refresh_age: 900
+          # skip refreshing tokens if already refreshed in last 110 minutes
+          # this assumes tokens provided by keycloak are valid for 120 minutes
+          auth_refresh_age: 6600
         JupyterHub:
           allow_named_servers: False
       extraConfig:


### PR DESCRIPTION
SSO tokens have an updated validity of 2 hours. This change ensures jupyterhub does not refresh the token when recieving a request for 110 minutes since a previous request