### PR TITLE
Remove producer from swan-cern chart fluentd configuration

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -315,7 +315,6 @@ fluentd:
     - fluent-plugin-out-http
     - fluent-plugin-grok-parser
   output:
-    producer: swan
     endpoint: http://monit-logs.cern.ch:10012/
     includeInternal: false
   parsingConfig: |


### PR DESCRIPTION
From now on, there will be two producers: swan and swan-qa. Those will be specified in the values.yaml of the prod and qa environments in the GitOps repo, respectively.