### PR TITLE
Fix refreshing of EOS kerberos ticket for notebooks and terminals (part 1)

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -135,12 +135,21 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
             )
         )
 
-        # define eos auth environment for the notebook container
+        # define eos kerberos credentials path for Jupyter server in notebook container
         notebook_container.env = self._add_or_replace_by_name(
             notebook_container.env,
             client.V1EnvVar(
                 name='KRB5CCNAME',
                 value='/srv/notebook/tokens/krb5cc'
+            ),
+        )
+
+        # define eos kerberos credentials path for notebook and terminal processes in notebook container
+        notebook_container.env = self._add_or_replace_by_name(
+            notebook_container.env,
+            client.V1EnvVar(
+                name='KRB5CCNAME_NB_TERM',
+                value='/srv/notebook/tokens/writable/krb5cc_nb_term'
             ),
         )
 


### PR DESCRIPTION
This commit is one of two parts of a fix for refreshing the EOS kerberos ticket in SWAN kubernetes, the other part being some changes in the systemuser image.

The current problem is that the EOS kerberos ticket that is used by the notebooks and terminal processes is never refreshed in k8s, only the ticket that is used by the Jupyter server is refreshed. This commit ensures both are refreshed, although the former can be overwritten by the user via kinit, which makes the user responsible for the ticket renewal from that point on.