### PR TITLE
Configure URL to SWAN gallery as an environment variable

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -97,6 +97,7 @@ jupyterhub:
       kubectl.kubernetes.io/default-container: notebook
     extraEnv:
       SWAN_DISABLE_NOTIFICATIONS: "true"
+      GALLERY_URL: "https://swan-gallery.web.cern.ch"
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
- This is used by notebook to render the link in the template
- Used by jupyterlab to load the iframe website

Used by https://github.com/swan-cern/systemuser-image/pull/95