### PR TITLE
Remove user pod affinity based on LCG release

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -92,6 +92,10 @@ swan:
       extraEnv:
         # Enable HTCondor service configuration for CERN in the user image
         CERN_HTCONDOR: "true"   
+    scheduling:
+      userPods:
+        nodeAffinity:
+          matchNodePurpose: ignore
     hub:
       extraVolumeMounts:
         - name: swan-jh-cern

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -29,9 +29,6 @@ class SwanPodHookHandler:
             pod_labels
         )
 
-        # init pod affinity
-        self.pod.spec.affinity = self._init_pod_affinity(pod_labels)
-
         if self._gpu_enabled():
             # currently no cern customisation required
             self.pod.spec.volumes.append(
@@ -86,29 +83,6 @@ class SwanPodHookHandler:
             return True
         else:
             return False
-
-    def _init_pod_affinity(self, pod_labels):
-        """
-        schedule pods to nodes that satisfy the specified label/affinity expressions 
-        """
-        try:
-            del pod_labels["swan_user"]
-        except KeyError:
-            pass
-        aff = client.V1Affinity()
-        pod_affinity = client.V1PodAffinity(
-            preferred_during_scheduling_ignored_during_execution=[client.V1WeightedPodAffinityTerm(
-                pod_affinity_term=client.V1PodAffinityTerm(
-                    label_selector=client.V1LabelSelector(
-                        match_labels=pod_labels
-                    ),
-                    topology_key="kubernetes.io/hostname"
-                ),
-                weight=100
-            )]
-        )
-        aff.pod_affinity = pod_affinity
-        return aff
 
     def _get_pod_container(self, container_name):
         """


### PR DESCRIPTION
Setting a pod affinity based on the LCG release that the user selected leads to pods being clustered in nodes by the kubernetes scheduler. This, together with overcommitting of the nodes, can cause memory pressure in crowded nodes where multiple users use the memory of their sessions up to the limit.

By removing this affinity setting, we seek to rely instead on the default strategy of the k8s scheduler, which tries to assign pods to least allocated nodes. This will make it less likely, unless the cluster is close to full capacity, that one or more users push a node's memory to the limit.

Note that the affinity setting was done to favour warm CVMFS caches in nodes so users had a better experience. However, most of our current users select the default software stack, the NXCALS stack or the CUDA stack, which are all warmed up automatically by our cron jobs. The few users that select other stacks will pay some cost for warming up their cache, but the penalty in time is not that significant anyway, i.e. the gains largely outweigh the losses with this change.