### PR TITLE
Update Chart.lock with eosxd 5.1.5

### DIFF
--- a/swan/Chart.lock
+++ b/swan/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.1.3
 - name: eosxd
   repository: http://registry.cern.ch/chartrepo/cern
-  version: 0.3.3
+  version: 5.1.5-1
 - name: cvmfs
   repository: https://registry.cern.ch/chartrepo/sciencebox
   version: 0.0.5
 - name: cvmfs-csi
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.0
-digest: sha256:01cd73d2c9e7794dc65d8a704552ca8e3a81ea394ede4ad3ba582cce5940b79d
-generated: "2022-08-03T16:19:53.07127986+02:00"
+digest: sha256:7e72f8364c891e78579a7f2b7e7316b696b0c5215e31bad710e4ad470aa5d9eb
+generated: "2023-01-24T11:28:12.692804114+01:00"


### PR DESCRIPTION
Missing update of the Chart.lock file, resulting from eosxd update.

If this update is not done, the Release Charts workflow fails because helm dependency update generates a modified Chart.lock.