### PR TITLE
Remove options specified upstream by eosxd chart

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -60,29 +60,6 @@ swan:
     deployDaemonSet: &eosDeployDS false
     deployCsiDriver: &eosDeployCSI true
     useCsiDriver: &eosUseCSI true
-  eosxd:
-    # we need to specify the mounts here otherwise cms/atlas won't be mounted properly
-    mounts:
-      ams: {}
-      atlas: {}
-      cms: {}
-      experiment: {}
-      hepdata: {}
-      opendata: {}
-      pps: {}
-      project:
-        project-i00: a e j g v k q y
-        project-i01: l h b p s f w n o
-        project-i02: d c i r m t u x z
-      theory: {}
-      user:
-        home-i00: d l n t z
-        home-i01: a g j k w
-        home-i02: h o r s y
-        home-i03: b e m v x
-        home-i04: c f i p q u
-      web: {}
-      workspace: {}
   jupyterhub:
     singleuser:
       memory:

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -66,10 +66,6 @@ fusex:
 # Ensure file versions are shown to allow notebook checkpoints
 # (the fusex chart already sets this as default)
 eosxd:
-  # onDelete gives us better control than RollingUpdate
-  # and prevents stopping all user sessions when we update EOS
-  updateStrategy:
-    type: OnDelete
   fuseconf:
     options:
       hide-versions: 0


### PR DESCRIPTION
Remove options of the eosxd chart that are now specified upstream, namely:

https://gitlab.cern.ch/kubernetes/automation/charts/cern/-/commit/f802519dc1f7625eadc65b7f0b7eb2d59b0986e9
https://gitlab.cern.ch/kubernetes/automation/charts/cern/-/commit/8a97f658dd4221c01ac8cf946394af4c15397738

Those options made it to the eosxd 5.1.5 tag.