### PR TITLE
Change resource settings for user pods, eosxd and cvmfs

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -62,8 +62,6 @@ swan:
     useCsiDriver: &eosUseCSI true
   jupyterhub:
     singleuser:
-      memory:
-        guarantee: 4G
       cpu:
         guarantee: 1
       extraEnv:
@@ -182,6 +180,9 @@ swan:
           auth_refresh_age: 6600
         JupyterHub:
           allow_named_servers: False
+        SwanKubeSpawner:
+          # memory request for user pod (fraction of the limit)
+          mem_request_fraction: 0.6
       extraConfig:
         00-authConf: |
           def pre_spawn_hook(authenticator, spawner, auth_state):

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -56,10 +56,17 @@ swan:
       - projects.cern.ch
       - sw.hsf.org
       - sndlhc.cern.ch
+    resources:
+      requests:
+        memory: 1.5G
   eos:
     deployDaemonSet: &eosDeployDS false
     deployCsiDriver: &eosDeployCSI true
     useCsiDriver: &eosUseCSI true
+  eosxd:
+    resources:
+      requests:
+        memory: 1.5G
   jupyterhub:
     singleuser:
       cpu:


### PR DESCRIPTION
This PR proposes a few changes in the resource specification of user, eosxd and cvmfs pods to:
- User pods: make the memory resource request dynamic, more precisely a fraction of the limit.
- eosxd and cvmfs: set a baseline memory request so that the k8s scheduler is aware from the start that such pods have some memory consumption.