### PR TITLE
Revert "Do not schedule CPU-only pods on GPU nodes"

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -33,10 +33,6 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
                 se_linux_options = spc_t_selinux
             )
             self.pod.spec.security_context = security_context
-        else:
-            # TODO: temporary setting to match non-gpu user pods to non-gpu nodes.
-            # To try to prevent EOS error in crowded gpu nodes until we update to EOS5
-            self.pod.spec.node_selector = {'beta.kubernetes.io/instance-type': 'm2.2xlarge'}
 
         return self.pod
 


### PR DESCRIPTION
This reverts commit 9aa2152835e668f7f8593ad796b926ecaa032bc6.

Since we are about to update to EOS v5, it is time to remove the limitation of GPU nodes not being able to schedule regular user sessions. This limitation was put in place because EOS v4 errors were more likely (and affected more people) in crowded GPU nodes.