### PR TITLE
Update Jupyterhub image to 1.30

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -137,7 +137,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v1.29"
+      tag: "v1.30"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
Contains changes in SwanSpawner to make the setting of the user pod memory request dynamic.