### PR TITLE
Update eosxd chart dependency to 5.1.5-2 tag

### DIFF
--- a/swan/Chart.lock
+++ b/swan/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.1.3
 - name: eosxd
   repository: http://registry.cern.ch/chartrepo/cern
-  version: 5.1.5-1
+  version: 5.1.5-2
 - name: cvmfs
   repository: https://registry.cern.ch/chartrepo/sciencebox
   version: 0.0.5
 - name: cvmfs-csi
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.0
-digest: sha256:7e72f8364c891e78579a7f2b7e7316b696b0c5215e31bad710e4ad470aa5d9eb
-generated: "2023-01-24T11:28:12.692804114+01:00"
+digest: sha256:b8304d5596334fc02842dfdadcea8be2c0c48d4f7fe9618c50d5676ae8e263f3
+generated: "2023-02-03T12:08:20.130785416+01:00"

--- a/swan/Chart.yaml
+++ b/swan/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://registry.cern.ch/chartrepo/eos
     condition: eos.deployDaemonSet
   - name: eosxd
-    version: 5.1.5-1
+    version: 5.1.5-2
     repository: http://registry.cern.ch/chartrepo/cern
     condition: eos.deployCsiDriver
 

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -66,9 +66,10 @@ fusex:
 # Ensure file versions are shown to allow notebook checkpoints
 # (the fusex chart already sets this as default)
 eosxd:
-  fuseconf:
-    options:
-      hide-versions: 0
+  config:
+    global:
+      options:
+        hide-versions: 0
 
 #
 # JupyerHub

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -72,7 +72,7 @@ eosxd:
         hide-versions: 0
 
 #
-# JupyerHub
+# JupyterHub
 #
 jupyterhub:
   singleuser:


### PR DESCRIPTION
New features:
- Possibility to specify configuration globally or per mount: used for `hide-versions:0`.
- New mounts: opendata and hepdata