### PR TITLE
Configure OpenCL to use NVIDIA backend

### DIFF
--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -63,6 +63,15 @@ class SwanPodHookHandler:
                 ),
             )
 
+            # Configure OpenCL to use NVIDIA backend
+            notebook_container.env = self._add_or_replace_by_name(
+                notebook_container.env,
+                client.V1EnvVar(
+                    name='OCL_ICD_FILENAMES',
+                    value='libnvidia-opencl.so.1'
+                ),
+            )
+
         # Disable adding environment variables from Kubernetes services in the same namespace
         self.pod.spec.enable_service_links = False
 


### PR DESCRIPTION
In order to run OpenCL programs on an NVIDIA GPU platform, OpenCL needs to be configured to use the NVIDIA vendor ICD (Installable Client Driver), i.e. the libnvidia-opencl library. The latter provides the OpenCL implementation that is specific for NVIDIA GPU architectures.

Such configuration can be achieved with the OCL_ICD_FILENAMES environment variable. More information here:

https://github.com/KhronosGroup/OpenCL-ICD-Loader

This is needed for the inverted CSC, in particular for an exercise session where `pyopencl` will be used.

For reference, SPI ticket with discussion about this topic:
https://sft.its.cern.ch/jira/browse/SPI-2300