### PR TITLE
Update images of jupyterhub and systemuser

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -138,7 +138,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v1.30"
+      tag: "v2.0"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
This includes:

- New JupyterHub image based on Alma9
- Dask HTCondor with TLS
- JupyterLab gallery (as part of SwanHelp)
- Fixes for cleaning hadoop and EOS secrets
- Removal of token generator scripts from charts to place them in the image of the corresponding component (hub, hadoop token generator)
