### PR TITLE
Update hub image to v2.1

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -138,7 +138,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v2.0"
+      tag: "v2.1"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
Fixes the need for kubernetes-client and helm in the hub image for sparkk8s_token.sh.