### PR TITLE
Adapt to OCI format

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -81,7 +81,6 @@ jobs:
     with:
       chart: swan
       bump: ${{ inputs.bump_swan }}
-      HELM_REPO_BASE_URL: https://registry.cern.ch/chartrepo/swan
     secrets:
       WORKFLOW_ACCESS_TOKEN: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
       HELM_REPO_USERNAME: ${{ secrets.HELM_REPO_USERNAME }}
@@ -132,7 +131,6 @@ jobs:
     with:
       chart: swan-cern
       bump: ${{ inputs.bump_swan_cern }}
-      HELM_REPO_BASE_URL: https://registry.cern.ch/chartrepo/swan
     secrets:
       WORKFLOW_ACCESS_TOKEN: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
       HELM_REPO_USERNAME: ${{ secrets.HELM_REPO_USERNAME }}

--- a/.github/workflows/tag-chart.yaml
+++ b/.github/workflows/tag-chart.yaml
@@ -17,10 +17,6 @@ on:
         required: true
         default: patch
         type: string
-      HELM_REPO_BASE_URL:
-        type: string
-        description: Helm repository base url
-        required: true
 
     secrets:
       WORKFLOW_ACCESS_TOKEN:
@@ -89,13 +85,10 @@ jobs:
           atomic: true
 
       - name: Push to helm registry
-        env:
-          HELM_REPO_USERNAME: ${{ secrets.HELM_REPO_USERNAME }}
-          HELM_REPO_PASSWORD: ${{ secrets.HELM_REPO_PASSWORD }}
         run: |
-          set -x
-          helm plugin install https://github.com/chartmuseum/helm-push --version v0.10.3
-          helm cm-push ${{ inputs.chart }}/ ${{ inputs.HELM_REPO_BASE_URL }}
+          helm registry login -u ${{ secrets.HELM_REPO_USERNAME }} -p ${{ secrets.HELM_REPO_PASSWORD }} ${{ vars.HELM_HARBOR_URL }}
+          helm package ${{ inputs.chart }}
+          helm push ${{ inputs.chart }}-${{ steps.version.outputs.new_version }}.tgz ${{ vars.HELM_REPO_BASE_URL }}
 
   publish_github_release:
     needs: [publish_chart]

--- a/swan-cern/Chart.lock
+++ b/swan-cern/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry.cern.ch/swan/charts
   version: 0.4.4
 - name: fluentd
-  repository: http://registry.cern.ch/chartrepo/cern
+  repository: oci://registry.cern.ch/cern
   version: 0.1.5
-digest: sha256:37a8420a49a9fb33eeac4026772a3578951447816e5a86b49a685e7c29ff5a19
-generated: "2023-04-17T16:40:33.984259689+02:00"
+digest: sha256:13661eff3eebfbb9832a2de6f327a83bbefc0d606d9d5f5974d587b23d0608af
+generated: "2023-04-17T16:59:16.47185838+02:00"

--- a/swan-cern/Chart.lock
+++ b/swan-cern/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: swan
-  repository: https://registry.cern.ch/chartrepo/swan
+  repository: oci://registry.cern.ch/swan/charts
   version: 0.4.4
 - name: fluentd
   repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.5
-digest: sha256:3b065bf15bc1dad16d13453c602536da5e71a7b35b2fad8daac82bc07dd743ad
-generated: "2023-04-05T14:24:48.690300576Z"
+digest: sha256:37a8420a49a9fb33eeac4026772a3578951447816e5a86b49a685e7c29ff5a19
+generated: "2023-04-17T16:40:33.984259689+02:00"

--- a/swan-cern/Chart.yaml
+++ b/swan-cern/Chart.yaml
@@ -11,7 +11,7 @@ description: The chart to deploy SWAN at CERN
 dependencies:
   - name: swan
     version: 0.4.4
-    repository: https://registry.cern.ch/chartrepo/swan
+    repository: oci://registry.cern.ch/swan/charts
   - name: fluentd
     repository: http://registry.cern.ch/chartrepo/cern
     version: 0.1.5

--- a/swan-cern/Chart.yaml
+++ b/swan-cern/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     version: 0.4.4
     repository: oci://registry.cern.ch/swan/charts
   - name: fluentd
-    repository: http://registry.cern.ch/chartrepo/cern
+    repository: oci://registry.cern.ch/cern
     version: 0.1.5


### PR DESCRIPTION
This includes:
- Changing the dependencies in our charts that are already published as OCI repository
- Change our CI/CD that tags our charts to use OCI instead of chartmuseum