### PR TITLE
Revert "Change fluentd dependency in swan-cern to OCI format"

### DIFF
--- a/swan-cern/Chart.lock
+++ b/swan-cern/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry.cern.ch/swan/charts
   version: 0.4.4
 - name: fluentd
-  repository: oci://registry.cern.ch/cern
+  repository: http://registry.cern.ch/chartrepo/cern
   version: 0.1.5
-digest: sha256:13661eff3eebfbb9832a2de6f327a83bbefc0d606d9d5f5974d587b23d0608af
-generated: "2023-04-17T16:59:16.47185838+02:00"
+digest: sha256:37a8420a49a9fb33eeac4026772a3578951447816e5a86b49a685e7c29ff5a19
+generated: "2023-04-17T16:40:33.984259689+02:00"

--- a/swan-cern/Chart.yaml
+++ b/swan-cern/Chart.yaml
@@ -13,5 +13,5 @@ dependencies:
     version: 0.4.4
     repository: oci://registry.cern.ch/swan/charts
   - name: fluentd
-    repository: oci://registry.cern.ch/cern
+    repository: http://registry.cern.ch/chartrepo/cern
     version: 0.1.5


### PR DESCRIPTION
This reverts commit cf1e86465421b20a63b2419304535cf192bb16ad.

The reason to revert is that the fluentd chart that is published as an OCI repository in Harbor is outdated. In particular, it still uses rbac.authorization.k8s.io/v1beta1, which was deprecated in 1.22.