### PR TITLE
auth: request openid scope for standard compliance

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -165,6 +165,7 @@ jupyterhub:
           - profile
           - email
           - offline_access
+          - openid
         exchange_tokens: []
         logout_redirect_url: https://cern.ch/swan
         auto_login: True


### PR DESCRIPTION
Keycloak is going to be updated at CERN and without this scope calls to userinfo endpoint will fail.

AFAIK nothing on our code calls this endpoint, except the EOS server that uses it to verify the validity of the token we send. But, since we still use krb in production, I don't expect anything to break, but...

I've made the same change in puppet qa, needs to be merged to prod and jupyterhubs restarted. But since this should not affect anyone, I leave that for your consideration.

[OTG0076533](https://cern.service-now.com/service-portal?id=outage&n=OTG0076533)