### PR TITLE
Update systemuser image to v5.18.2

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-      tag: "v5.18.1"
+      tag: "v5.18.2"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
Contains fix for not taking Python modules placed on SWAN_HOME.