### PR TITLE
Update systemuser image to v5.18.3

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-      tag: "v5.18.2"
+      tag: "v5.18.3"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
Has fix for not depending on user-defined labextension.yaml to select SwanHTCondorCluster.