### PR TITLE
Reduce allowed session inactivity period to 4 hours

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -186,8 +186,8 @@ swan:
           
     custom:
       cull:
-        # 6 hours
-        timeout: 21600
+        # 4 hours
+        timeout: 14400
         checkEosAuth: true
         hooksDir: /srv/jupyterhub/culler
       cvmfs:


### PR DESCRIPTION
This is to claim back resources more quickly, which is becoming especially important in the case of GPUs. It still gives enough time for pauses during the day without losing the session.