### PR TITLE
When session fails to start, mention that all GPUs might be busy

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -168,6 +168,7 @@ swan:
           SPAWN_ERROR_MESSAGE = """SWAN could not start a session for your user, please try again. If the problem persists, please check:
           <ul>
               <li>Do you have a CERNBox account? If not, click <a href="https://cernbox.cern.ch" target="_blank">here</a>.</li>
+              <li>If you requested a GPU, are all of them busy? Please ask <a href="https://cern.service-now.com/service-portal?id=functional_element&name=swan" target="_blank">SWAN Support</a>.</li>
               <li>Is there a problem with the service? Find information <a href="https://cern.service-now.com/service-portal?id=service_status_board" target="_blank">here</a>.</li>
               <li>If none of the options apply, please open a <a href="https://cern.service-now.com/service-portal?id=functional_element&name=swan" target="_blank">Support Ticket</a>.</li>
           </ul>"""


### PR DESCRIPTION
It is becoming common that users fail to start a GPU session because of lack of resources. This will hint them in that direction.