### PR TITLE
Update hadoop token generator image to v2.1.2

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -255,7 +255,7 @@ swanCern:
       cred:
 
 hadoopTokenGenerator:
-  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v2.1.1
+  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v2.1.2
 
 fluentd:
   containerRuntime: containerd


### PR DESCRIPTION
Fix to pick newer hadoop-fetchdt version.