### PR TITLE
Move daemonset to kube-system namespace

### DIFF
--- a/swan-cern/templates/gpu/nvidia-hack-force-mig-config.yaml
+++ b/swan-cern/templates/gpu/nvidia-hack-force-mig-config.yaml
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-hack-force-mig-config
-  namespace: {{ .Release.Namespace }}
+  namespace: kube-system
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Since it needs to access the admin service account in that namespace.

This hack is needed because of the race condition reported here: https://github.com/NVIDIA/k8s-device-plugin/issues/253
