### PR TITLE
Clean GPU-related logic in spawner hooks

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -24,15 +24,7 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         # init user containers (notebook and side-container)
         self._init_eos_containers(eos_secret_name)
 
-        if self._gpu_enabled():
-            # spc_t type is added as recommended by CM
-            spc_t_selinux = client.V1SELinuxOptions(
-                type = "spc_t"
-            )
-            security_context = client.V1PodSecurityContext(
-                se_linux_options = spc_t_selinux
-            )
-            self.pod.spec.security_context = security_context
+        self._check_gpu_access()
 
         return self.pod
 
@@ -209,12 +201,10 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         # assigning pod spec containers
         self.pod.spec.containers = pod_spec_containers
 
-    def _gpu_enabled(self):
+    def _check_gpu_access(self):
         """
         Helper function to determine if gpu is allowed for given spawn
         raise exception if user has not access to the gpu
-        return True if gpu is selected and user has access to gpu
-        return False if gpu is not selected
         """
 
         user_roles = self.spawner.user_roles
@@ -223,9 +213,6 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         if "cu" in lcg_rel and "swan-gpu" not in user_roles:
             raise ValueError("""Access to GPUs is not granted;
     please <a href="https://cern.service-now.com/service-portal?id=functional_element&name=swan" target="_blank">open a Support Ticket</a>""")
-        elif "cu" in lcg_rel:
-            return True
-        return False
 
 # https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html
 # This is defined in the configuration to allow overring iindependently 

--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -24,8 +24,6 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         # init user containers (notebook and side-container)
         self._init_eos_containers(eos_secret_name)
 
-        self._check_gpu_access()
-
         return self.pod
 
     def _init_eos_secret(self):
@@ -200,19 +198,6 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
 
         # assigning pod spec containers
         self.pod.spec.containers = pod_spec_containers
-
-    def _check_gpu_access(self):
-        """
-        Helper function to determine if gpu is allowed for given spawn
-        raise exception if user has not access to the gpu
-        """
-
-        user_roles = self.spawner.user_roles
-        lcg_rel = self.spawner.user_options[self.spawner.lcg_rel_field]
-
-        if "cu" in lcg_rel and "swan-gpu" not in user_roles:
-            raise ValueError("""Access to GPUs is not granted;
-    please <a href="https://cern.service-now.com/service-portal?id=functional_element&name=swan" target="_blank">open a Support Ticket</a>""")
 
 # https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html
 # This is defined in the configuration to allow overring iindependently 

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -63,15 +63,6 @@ class SwanPodHookHandler:
                 ),
             )
 
-            # Configure OpenCL to use NVIDIA backend
-            notebook_container.env = self._add_or_replace_by_name(
-                notebook_container.env,
-                client.V1EnvVar(
-                    name='OCL_ICD_FILENAMES',
-                    value='libnvidia-opencl.so.1'
-                ),
-            )
-
         # Disable adding environment variables from Kubernetes services in the same namespace
         self.pod.spec.enable_service_links = False
 

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -29,60 +29,10 @@ class SwanPodHookHandler:
             pod_labels
         )
 
-        if self._gpu_enabled():
-            # currently no cern customisation required
-            self.pod.spec.volumes.append(
-                client.V1Volume(
-                    host_path=client.V1HostPathVolumeSource(path="/opt/nvidia-driver"),
-                    name='nvidia-driver'
-                )
-            )
-
-            notebook_container = self._get_pod_container('notebook')
-
-            notebook_container.volume_mounts.append(
-                client.V1VolumeMount(
-                name='nvidia-driver',
-                mount_path='/opt/nvidia-driver'
-                )
-            )
-
-            notebook_container.env = self._add_or_replace_by_name(
-                notebook_container.env,
-                client.V1EnvVar(
-                    name='NVIDIA_LIB_PATH',
-                    value='/opt/nvidia-driver/lib64'
-                ),
-            )
-
-            notebook_container.env = self._add_or_replace_by_name(
-                notebook_container.env,
-                client.V1EnvVar(
-                    name='NVIDIA_PATH',
-                    value='/opt/nvidia-driver/bin'
-                ),
-            )
-
         # Disable adding environment variables from Kubernetes services in the same namespace
         self.pod.spec.enable_service_links = False
 
         return self.pod
-
-    def _gpu_enabled(self):
-        """
-        Helper function to determine if gpu is allowed for given spawn
-        raise exception if user has not access to the gpu
-        return True if gpu is selected and user has access to gpu
-        return False if gpu is not selected
-        """
-
-        user_roles = self.spawner.user_roles
-        lcg_rel = self.spawner.user_options[self.spawner.lcg_rel_field]
-
-        if "cu" in lcg_rel:
-            return True
-        else:
-            return False
 
     def _get_pod_container(self, container_name):
         """


### PR DESCRIPTION
Remove settings that are no longer necessary in the spawner hooks w.r.t. GPU configuration, or move them to the SwanKubeSpawner if they are still needed.