### PR TITLE
Fix message when user does not have access to analytix

### DIFF
--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -178,7 +178,7 @@ class SwanSparkPodHookHandler(SwanPodHookHandlerProd):
            raise ValueError(
               """
               Access to the Analytix cluster is not granted. 
-              Please <a href="https://hadoop.web.cern.ch/" target="_blank">request access</a>
+              Please <a href="https://cern.service-now.com/service-portal?id=sc_cat_item&name=access-cluster-hadoop&se=Hadoop-Service" target="_blank">request access</a>
               """)
         elif cluster == "hadoop-nxcals" and "hadoop-nxcals" not in user_roles:
            raise ValueError(


### PR DESCRIPTION
Link to the SNOW form of the Hadoop service.
https://hadoop.web.cern.ch does not exist.