### PR TITLE
Upgrade user image to v5.18.5

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-      tag: "v5.18.4"
+      tag: "v5.18.5"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
In preparation for https://cern.service-now.com/service-portal?id=outage&n=OTG0079117