### PR TITLE
Propagate SWAN_DEV env variable to culler service

### DIFF
--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -129,6 +129,7 @@ if get_config("custom.cull.enabled", False):
             "name": "cull-idle",
             "admin": True,
             "command": cull_cmd,
+            "environment": {'SWAN_DEV': os.environ.get('SWAN_DEV', 'false')}
         }
     )
 


### PR DESCRIPTION
The culler service invokes check_ticket.sh, which invokes eos_token.sh, which makes use of the SWAN_DEV variable to decide on its behaviour.

Without this setting, the culler service does not get such variable from the hub, even when it's set for a dev cluster.