### PR TITLE
Update hadoop token generator image to v2.1.3

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -256,7 +256,7 @@ swanCern:
       cred:
 
 hadoopTokenGenerator:
-  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v2.1.2
+  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v2.1.3
 
 fluentd:
   caCertPath: &fluentdCaCertPath /etc/ssl/ca-bundle.crt


### PR DESCRIPTION
Uses alma9 repository for hadoop fetchdt package.