### PR TITLE
Update user image to v5.18.9

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/systemuser"
-      tag: "v5.18.8"
+      tag: "v5.18.9"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
Fix for creating centos7 kerberos tickets that are used by an alma9 eosxd.