### PR TITLE
Turn Spark pod hook into a generic hook for handling external computing integrations

### DIFF
--- a/swan-cern/files/swan_computing_config.py
+++ b/swan-cern/files/swan_computing_config.py
@@ -63,7 +63,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
             return None
 
         username = self.spawner.user.name
-        hadoop_secret_name ='hadoop-tokens-%s' % username
+        hadoop_secret_name = f'hadoop-tokens-{username}'
 
         webhdfs_token_base64 = ''
         k8suser_config_base64 = ''
@@ -120,7 +120,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
             else:
                 await self.spawner.api.create_namespaced_secret(swan_container_namespace, secret_data)
         except ApiException as e:
-            raise Exception("Could not create required hadoop secret: %s\n" % e)
+            raise Exception(f'Could not create required hadoop secret: {e}\n')
 
         return hadoop_secret_name
 
@@ -299,7 +299,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
         computing resources.
         """
 
-        computing_ports_service = "computing-ports-" + self.spawner.user.name
+        computing_ports_service = f'computing-ports-{self.spawner.user.name}'
         notebook_container = self._get_pod_container('notebook')
 
         try:
@@ -308,7 +308,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
             for port_id in range(1, num_ports + 1):
                 service_template_ports.append(
                     V1ServicePort(
-                        name="comp-port-" + str(port_id),
+                        name=f'comp-port-{str(port_id)}',
                         port=port_id
                     )
                 )
@@ -334,7 +334,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
                 try:
                     service = await self.spawner.api.create_namespaced_service(swan_container_namespace, service_template)
                 except ApiException as e:
-                    raise Exception("Could not create service that allocates random ports for computing integrations: %s\n" % e)
+                    raise Exception(f'Could not create service that allocates random ports for computing integrations: {e}\n')
 
             # Replace the service with allocated nodeports to map nodeport:targetport
             # and set these ports for the notebook container
@@ -373,7 +373,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
                 )
             )
         except ApiException as e:
-            raise Exception("Could not create required user ports: %s\n" % e)
+            raise Exception(f'Could not create required user ports: {e}\n')
 
 
 def computing_modify_pod_hook(spawner, pod):

--- a/swan-cern/files/swan_computing_config.py
+++ b/swan-cern/files/swan_computing_config.py
@@ -120,7 +120,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
             else:
                 await self.spawner.api.create_namespaced_secret(swan_container_namespace, secret_data)
         except ApiException as e:
-            raise Exception(f'Could not create required hadoop secret: {e}\n')
+            raise RuntimeError('Could not create required hadoop secret') from e
 
         return hadoop_secret_name
 
@@ -334,7 +334,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
                 try:
                     service = await self.spawner.api.create_namespaced_service(swan_container_namespace, service_template)
                 except ApiException as e:
-                    raise Exception(f'Could not create service that allocates random ports for computing integrations: {e}\n')
+                    raise RuntimeError('Could not create service that allocates random ports for computing integrations') from e
 
             # Replace the service with allocated nodeports to map nodeport:targetport
             # and set these ports for the notebook container
@@ -373,7 +373,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
                 )
             )
         except ApiException as e:
-            raise Exception(f'Could not create required user ports: {e}\n')
+            raise RuntimeError('Could not create required user ports') from e
 
 
 def computing_modify_pod_hook(spawner, pod):

--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -178,8 +178,6 @@ class SwanSparkPodHookHandler(SwanPodHookHandlerProd):
         """
 
         user_roles = self.spawner.user_roles
-        print(self.spawner.user_options)
-        print(self.spawner.user_roles)
         cluster = self.spawner.user_options[self.spawner.spark_cluster_field]
 
         if cluster == "analytix" and "analytix" not in user_roles:

--- a/swan-cern/files/swan_spark_config.py
+++ b/swan-cern/files/swan_spark_config.py
@@ -295,7 +295,6 @@ class SwanSparkPodHookHandler(SwanPodHookHandlerProd):
             # Create V1Service which allocates random ports for spark in k8s cluster
             try:
                 # use existing if possible
-                await self.spawner.api.delete_namespaced_service(spark_ports_service, swan_container_namespace)
                 service = await self.spawner.api.read_namespaced_service(spark_ports_service, swan_container_namespace)
             except ApiException:
                 # not existing, create

--- a/swan-cern/templates/config.yaml
+++ b/swan-cern/templates/config.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   options_form_config.json: {{ .Values.optionsform | toJson }}
 {{ (.Files.Glob "files/swan_config_cern.py").AsConfig | indent 2 }}
-{{ (.Files.Glob "files/swan_spark_config.py").AsConfig | indent 2 }}
+{{ (.Files.Glob "files/swan_computing_config.py").AsConfig | indent 2 }}
 {{ (.Files.Glob "files/private/side_container_tokens_perm.sh").AsConfig | indent 2 }}

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -88,8 +88,8 @@ swan:
           mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/2_swan_config_cern.py
           subPath: swan_config_cern.py
         - name: swan-jh-cern
-          mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/3_swan_spark_config.py
-          subPath: swan_spark_config.py
+          mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/3_swan_computing_config.py
+          subPath: swan_computing_config.py
         - name: swan-secrets
           mountPath: /srv/jupyterhub/private/eos.cred
           subPath: eos.cred
@@ -120,8 +120,8 @@ swan:
               path: options_form_config.json
             - key: swan_config_cern.py
               path: swan_config_cern.py
-            - key: swan_spark_config.py
-              path: swan_spark_config.py
+            - key: swan_computing_config.py
+              path: swan_computing_config.py
         - name: swan-secrets
           secret:
             secretName: swan-cern

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -72,9 +72,6 @@ swan:
     singleuser:
       cpu:
         guarantee: 1
-      extraEnv:
-        # Enable HTCondor service configuration for CERN in the user image
-        CERN_HTCONDOR: "true"   
     scheduling:
       userPods:
         nodeAffinity:


### PR DESCRIPTION
This is to implement a special treatment for HTCondor pools at the level of the modifier pod hook.

Now Spark and HTCondor will share a hook, which will configure both. The reason for this is that both share the need to open ports in the user session. Depending on what the user selects in the form (Spark, HTCondor or both) we will create a k8s service that provides the corresponding ports.
