### PR TITLE
Update hub image to v3.4

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -139,7 +139,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v3.2"
+      tag: "v3.4"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
Contains changes to support the new Spark k8s cluster.

To be merged after confirmation that all QA tests are fine.