### PR TITLE
Use alma9 user image swan-cern v0.0.2

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern"
-      tag: "v0.0.1"
+      tag: "v0.0.2"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
To release a new tag of the charts that uses the new swan-cern:v0.0.2, on which we are going to work next (Spark, Condor, other fixes).