### PR TITLE
Update JupyterHub image to v3.6

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -139,7 +139,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v3.5"
+      tag: "v3.6"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
Includes spawner support for HTCondor integration.