### PR TITLE
Allocate half of a CPU per user session

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -71,7 +71,7 @@ swan:
   jupyterhub:
     singleuser:
       cpu:
-        guarantee: 1
+        guarantee: 0.5
     scheduling:
       userPods:
         nodeAffinity:


### PR DESCRIPTION
This value was changed, as the puppet nodes are being taken out of service and so, there will be a higher number of user sessions running in the SWAN kubernetes cluster.

Therefore, taking into account the maximum number of CPUs available, it was decided to allocate half of a CPU per user session, to allow for more user sessions to be scheduled.