### PR TITLE
Change EOS chart used by SWAN

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -49,15 +49,6 @@ swan:
               source /cvmfs/sft.cern.ch/lcg/views/{{ .Values.global.cuda.lcg }}/{{ .Values.global.cuda.platform }}/setup.sh &&
               (timeout 20s python3 -c 'import tensorflow' || true) &&
               (timeout 20s python3 -c 'import torch' || true)
-
-  eos:
-    deployDaemonSet: &eosDeployDS false
-    deployCsiDriver: &eosDeployCSI true
-    useCsiDriver: &eosUseCSI true
-  eosxd:
-    resources:
-      requests:
-        memory: 1.5G
   jupyterhub:
     singleuser:
       cpu:
@@ -187,10 +178,6 @@ swan:
         timeout: 14400
         checkEosAuth: true
         hooksDir: /srv/jupyterhub/culler
-      eos:
-        deployDaemonSet: *eosDeployDS
-        deployCsiDriver: *eosDeployCSI
-        useCsiDriver: *eosUseCSI
       spark:
         configurationPath: /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext
 swanCern:

--- a/swan/Chart.yaml
+++ b/swan/Chart.yaml
@@ -22,4 +22,4 @@ dependencies:
   - name: cvmfs-csi
     version: 2.5.0
     repository: oci://registry.cern.ch/kubernetes/charts
-    condition: cvmfs-csi.deployCsiDriver
+    condition: cvmfs-csi.enabled

--- a/swan/Chart.yaml
+++ b/swan/Chart.yaml
@@ -15,15 +15,10 @@ dependencies:
   - name: jupyterhub
     version: 3.1.0
     repository: https://jupyterhub.github.io/helm-chart/
-
-  - name: fusex
-    version: 0.1.3
-    repository: https://registry.cern.ch/chartrepo/eos
-    condition: eos.deployDaemonSet
-  - name: eosxd
-    version: 5.1.27-1
-    repository: http://registry.cern.ch/chartrepo/cern
-    condition: eos.deployCsiDriver
+  - name: eosxd-csi
+    version: 1.4.2
+    repository: oci://registry.cern.ch/kubernetes/charts
+    condition: eosxd-csi.enabled
   - name: cvmfs-csi
     version: 2.5.0
     repository: oci://registry.cern.ch/kubernetes/charts

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -174,9 +174,8 @@ c.SwanKubeSpawner.volume_mounts.append(
 )
 
 # Manage EOS access
-if get_config("custom.eos.deployDaemonSet", False):
+if get_config("custom.eos.enabled", False):
     # Access via bind-mount from the host
-    logging.info("EOS access via DaemonSet")
     c.SwanKubeSpawner.volume_mounts.append(
         V1VolumeMount(
             name='eos',
@@ -188,26 +187,7 @@ if get_config("custom.eos.deployDaemonSet", False):
         V1Volume(
             name='eos',
             host_path=V1HostPathVolumeSource(
-                path='/var/eos'
-            )
-        ),
-    )
-elif (get_config("custom.eos.deployCsiDriver", False) or \
-        get_config("custom.eos.useCsiDriver", False)):
-    # Access via CSI driver (still a bind-mount in practical terms)
-    logging.info("EOS access via CSI driver")
-    c.SwanKubeSpawner.volume_mounts.append(
-        V1VolumeMount(
-            name='eos',
-            mount_path='/eos',
-            mount_propagation='HostToContainer'
-        ),
-    )
-    c.SwanKubeSpawner.volumes.append(
-        V1Volume(
-            name='eos',
-            host_path=V1HostPathVolumeSource(
-                path='/var/eos'
+                path=get_config("custom.eos.automountHostPath", "/var/eos")
             )
         ),
     )

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -10,34 +10,13 @@ cvmfs-csi:
 
 #
 # EOS access
-# - deployDaemonSet deploys EOS fusex pods exposing `/eos` path on the host.
-#     Access to EOS is provided by bind-mounting `/eos` from the host.
-# - deployCsiDriver deploys a cluster-wide storage driver for EOS.
-#     Access to EOS is provided by persistent volume claims.
-# - useCsiDriver has to be used in case the hosting infrastructure provides
-#       a CSI driver to access EOS (i.e., it is not needed to deploy additional pods).
-#     Access to EOS is provided by persistent volume claims (identical to deployCsiDriver).
+# - We deploy a cluster-wide storage driver for EOS, provided by the
+#   Kubernetes team at CERN (https://gitlab.cern.ch/kubernetes/storage/eosxd-csi).
+#   This solution is based on automounting.
 #
-# Warning:
-# - It is discouraged to enable more than one at once.
-# - By setting all to false, access to EOS will not be possible.
-#     You will need to set `juyterhub.hub.config.SwanKubeSpawner.local_home: true`
-#
-eos:
-  deployDaemonSet: &eosDeployDS true
-  deployCsiDriver: &eosDeployCSI false
-  useCsiDriver: &eosUseCSI false
-fusex:
-  fusex:
-    hostMountpoint: /var/eos
-
-# Ensure file versions are shown to allow notebook checkpoints
-# (the fusex chart already sets this as default)
-eosxd:
-  config:
-    global:
-      options:
-        hide-versions: 0
+eosxd-csi:
+  enabled:  &eosEnabled true
+  automountHostPath: &eosAutomountHostPath /var/eos-blue
 
 #
 # JupyterHub
@@ -200,9 +179,8 @@ jupyterhub:
       users: true
       checkEosAuth: false
     eos:
-      deployDaemonSet: *eosDeployDS
-      deployCsiDriver: *eosDeployCSI
-      useCsiDriver: *eosUseCSI
+      enabled: *eosEnabled
+      automountHostPath: *eosAutomountHostPath
 # placeholders for swan credentials
 swan:
   secrets:

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -5,8 +5,8 @@
 #   This solution is based on automounting.
 #
 cvmfs-csi:
+  enabled: true
   automountHostPath: /var/cvmfs-blue
-  deployCsiDriver: true
 
 #
 # EOS access


### PR DESCRIPTION
Use eosxd-csi chart for EOS as the old chart was no longer maintained (fusex). Furthermore, removed unused eos chart that was present in the SWAN chart Chart.yaml file.

This new chart allows to specify custom mountpoints on the nodes of the kubernetes cluster, which was a limitation of the fusex chart, meaning that it is possible to have two different deployments of EOS running in the same kubernetes cluster.