### PR TITLE
Replace ingress class annotation with ingressClassName chart value

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -97,8 +97,8 @@ jupyterhub:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-body-size: 100m
+    ingressClassName: nginx
     #tls:
     #  - secretName: swan-tls-cert
     # placeholder for hostname


### PR DESCRIPTION
The ingress class annotation is deprecated and so it was replaced.