### PR TITLE
add /cvmfs/grid.cern.ch

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -232,6 +232,7 @@ swan:
           - mount: fcc.cern.ch
           - mount: ganga.cern.ch
           - mount: geant4.cern.ch
+          - mount: grid.cern.ch
           - mount: lhcb.cern.ch
             proxy: 'http://ca-proxy-lhcb.cern.ch:3128;http://ca-proxy.cern.ch:3128'
           - mount: lhcb-condb.cern.ch

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -48,6 +48,7 @@ swan:
       - fcc.cern.ch
       - ganga.cern.ch
       - geant4.cern.ch
+      - grid.cern.ch
       - lhcb.cern.ch
       - lhcb-condb.cern.ch
       - lhcbdev.cern.ch
@@ -232,7 +233,6 @@ swan:
           - mount: fcc.cern.ch
           - mount: ganga.cern.ch
           - mount: geant4.cern.ch
-          - mount: grid.cern.ch
           - mount: lhcb.cern.ch
             proxy: 'http://ca-proxy-lhcb.cern.ch:3128;http://ca-proxy.cern.ch:3128'
           - mount: lhcb-condb.cern.ch


### PR DESCRIPTION
Not sure if it also needs to be added to the list of repos on line 30 ? But /cvmfs/grid.cern.ch has the certs etc to make voms proxies work on the client side.