### PR TITLE
Update hub image to v3.10

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -139,7 +139,7 @@ jupyterhub:
       enabled: false
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
-      tag: "v3.9"
+      tag: "v3.10"
       pullPolicy: "Always"
     extraVolumeMounts:
       - name: swan-jh


### PR DESCRIPTION
Has a new spawner version that implements allocation of event participants in specific resources.