### PR TITLE
Update swan-cern image to v0.0.13

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -82,7 +82,7 @@ jupyterhub:
       type: none
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern"
-      tag: "v0.0.12"
+      tag: "v0.0.13"
       pullPolicy: "Always"
     cloudMetadata:
       # until we configure networkPolicy


### PR DESCRIPTION
Has support for voms-proxy-init on Alma9.