### PR TITLE
swan-cern: Revert addition of grid.cern.ch repository to CVMFS

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -48,7 +48,6 @@ swan:
       - fcc.cern.ch
       - ganga.cern.ch
       - geant4.cern.ch
-      - grid.cern.ch
       - lhcb.cern.ch
       - lhcb-condb.cern.ch
       - lhcbdev.cern.ch


### PR DESCRIPTION
This change is temporary, as it is not intended to be deployed in the next service intervention.