### PR TITLE
ci: Use different separator for sed command

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -24,7 +24,7 @@ jobs:
         echo "Updating information for image = ${{ github.event.inputs.image }} version = ${{ github.event.inputs.version }}"
         export IMAGE_NAME=${{ github.event.inputs.image }}
         export IMAGE_VERSION=$(echo ${{ github.event.inputs.version }} | sed -e "s/v//g")
-        sed -i "s/\(gitlab-registry.cern.ch\/swan\/docker-images\/$IMAGE_NAME:*\)[^ ]*/\1$IMAGE_VERSION/" swan/values.yaml
+        sed -i "s|\(gitlab-registry.cern.ch/swan/docker-images/$IMAGE_NAME:\)[^ ]*|\1$IMAGE_VERSION|" swan/values.yaml
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
This is to prevent errors with the sed command, since the / is also used to indicate the path of the docker image that will have their version replaced.