### PR TITLE
swan-cern: Update user image tag to v.0.0.21

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -12,7 +12,7 @@ global:
 
 user-image:
   name:  &userImageName "gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern"
-  tag: &userImageTag "v0.0.20"
+  tag: &userImageTag "v0.0.21"
 
 swan:
   cvmfs-csi:


### PR DESCRIPTION
Contains installation of cronie for cvmfs-csi prefetcher.