### PR TITLE
Deploy cvmfs storage class through cvmfs-csi chart

### DIFF
--- a/swan/templates/cvmfs/pvc.yaml
+++ b/swan/templates/cvmfs/pvc.yaml
@@ -1,9 +1,3 @@
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: cvmfs
-provisioner: cvmfs.csi.cern.ch
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -7,6 +7,8 @@
 cvmfs-csi:
   enabled: true
   automountHostPath: /var/cvmfs-blue
+  automountStorageClass:
+    create: true
 
 #
 # EOS access


### PR DESCRIPTION
Deploy it through the cvmfs-csi chart instead of defining it in the swan chart, for simplicity purposes