### PR TITLE
swan: Set default host mountpoints for EOS and CVMFS

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -6,7 +6,7 @@
 #
 cvmfs-csi:
   enabled: true
-  automountHostPath: /var/cvmfs-blue
+  automountHostPath: /var/cvmfs
   automountStorageClass:
     create: true
 
@@ -18,7 +18,7 @@ cvmfs-csi:
 #
 eosxd-csi:
   enabled:  &eosEnabled true
-  automountHostPath: /var/eos-blue
+  automountHostPath: /var/eos
   commonStorageClass:
     enabled: true
 


### PR DESCRIPTION
Mount EOS and CVMFS on the default paths, if the goal is to only have one SWAN deployment.