### PR TITLE
[swan-cern] Update swan-cern image to v0.0.24

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -57,7 +57,7 @@ swan:
         guarantee: 0.5
       image:
         name: gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern
-        tag: v0.0.23
+        tag: v0.0.24
     scheduling:
       userPods:
         nodeAffinity:


### PR DESCRIPTION
Contains fix for SwanShare and SwanContents in hub v4.1.6