### PR TITLE
Add network policies to restrict traffic in user pods

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -58,6 +58,31 @@ swan:
       image:
         name: gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern
         tag: v0.0.27
+      networkPolicy:
+        ingress:
+          # Allow user pods to receive incoming connections on the NodePort service port range.
+          # This supports use cases where servers run inside the user pod and need to receive
+          # connections (e.g. Spark, HTCondor via Dask).
+          - from:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+                # Exclude connections from other pods in our cluster's pod network.
+                except:
+                  - 10.0.0.0/8
+                  - 172.16.0.0/12
+                  - 192.168.0.0/16
+            ports:
+            - protocol: TCP
+              port: 30000
+              endPort: 32767
+        egress:
+          # Allow connection from the user pod to the hadoop token generator to get Hadoop credentials.
+          - to:
+              - podSelector:
+                  matchLabels:
+                    app: hadoop-token-generator
+            ports:
+              - port: 80
     scheduling:
       userPods:
         nodeAffinity:
@@ -174,6 +199,16 @@ swan:
           description: Access to hub Prometheus metrics
           scopes: ['read:metrics']
           services: [prometheus-service-monitor]
+      networkPolicy:
+        ingress:
+          # Allow connection from prometheus to the hub, to scrape the metrics endpoint
+          - ports:
+              - protocol: TCP
+                port: 8081
+            from:
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: prometheus
     custom:
       cull:
         # 4 hours

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -55,11 +55,12 @@ jupyterhub:
       tag: "v0.0.14"
       pullPolicy: "Always"
     cloudMetadata:
-      # until we configure networkPolicy
-      blockWithIptables: true
       ip: 169.254.169.254
     networkPolicy:
-      enabled: false
+      enabled: true
+      egressAllowRules:
+        dnsPortsCloudMetadataServer: false
+        dnsPortsPrivateIPs: false
     extraAnnotations:
       kubectl.kubernetes.io/default-container: notebook
     extraEnv:
@@ -77,6 +78,13 @@ jupyterhub:
     service:
       type: ClusterIP
     chp:
+      networkPolicy:
+        enabled: true
+        egressAllowRules:
+          cloudMetadataServer: false
+          dnsPortsCloudMetadataServer: false
+          dnsPortsPrivateIPs: false
+          privateIPs: false
       image:
         name: "jupyterhub/configurable-http-proxy"
         tag: "4.5.0"
@@ -174,7 +182,12 @@ jupyterhub:
           raise Exception("Please configure pre_spawn_hook")
         c.KeyCloakAuthenticator.pre_spawn_hook = pre_spawn_hook
     networkPolicy:
-      enabled: false
+      enabled: true
+      egressAllowRules:
+        cloudMetadataServer: false
+        dnsPortsCloudMetadataServer: false
+        dnsPortsPrivateIPs: false
+        privateIPs: false
     # placeholder for hub cookieSecret
     # when empty, it generates a new randomly
     cookieSecret:
@@ -209,4 +222,3 @@ swan:
     ingress:
       cert:
       key:
-


### PR DESCRIPTION
This change intends to increase security by only allowing the user pods to communicate with authorized resources, such as the hub and proxy and allow incoming traffic from specific origins, including spark and htcondor.