### PR TITLE
swan-cern: Remove node-feature-discovery values

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -351,8 +351,3 @@ gpu-operator:
     config:
       name: nvidia-device-plugin-config
       default: "default"
-  node-feature-discovery:
-    image:
-      repository: registry.cern.ch/kubernetes/node-feature-discovery
-      tag: v0.10.1
-


### PR DESCRIPTION
The node-feature-discovery component values are no longer under the gpu-operator ones and are now defined seperately in the upstream cern-magnum chart. This commit reflects such change