### PR TITLE
ci: Trigger chart release if swan-cern-system has changes

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -81,7 +81,7 @@ jobs:
           set -euxo pipefail
           ./.github/workflows/list-changed-charts.sh >> $GITHUB_OUTPUT
       - name: Fail if no charts have changes
-        if: steps.diff.outputs.swan_has_changed != 'true' && steps.diff.outputs.swan-cern_has_changed != 'true'
+        if: steps.diff.outputs.swan_has_changed != 'true' && steps.diff.outputs.swan-cern_has_changed != 'true' && steps.diff.outputs.swan-cern-system_has_changed != 'true'
         run: exit 1
   
 


### PR DESCRIPTION
Only fail the pipeline if none of the three charts has changes.