### PR TITLE
swan-cern-system: Disable monitoring chart

### DIFF
--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -119,4 +119,4 @@ gpu-operator:
       default: "default"
 
 cern-it-monitoring-kubernetes:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
It was decided to disable the chart for now, as it requires further investigation on how to use it and the parameters to set regarding resources usage