### PR TITLE
fix: Disable blocking the cloud metadata server with iptables

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -55,6 +55,7 @@ jupyterhub:
       tag: "v0.0.14"
       pullPolicy: "Always"
     cloudMetadata:
+      blockWithIptables: false
       ip: 169.254.169.254
     networkPolicy:
       enabled: true


### PR DESCRIPTION
This is already done by the network policies set in place by us.