### PR TITLE
[swan-cern] Update swan-cern image to v0.0.28

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -60,7 +60,7 @@ swan:
         guarantee: 0.5
       image:
         name: gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern
-        tag: v0.0.27
+        tag: v0.0.28
       networkPolicy:
         ingress:
           # Allow user pods to receive incoming connections on the NodePort service port range.


### PR DESCRIPTION
Contains SparkConnector 3.0.5 with a fix for Spark session logs.