### PR TITLE
[swan-cern] Install diff

### DIFF
--- a/swan-cern/files/private/side_container_tokens_perm.sh
+++ b/swan-cern/files/private/side_container_tokens_perm.sh
@@ -45,6 +45,10 @@ echo "start refreshing EOS kerberos tickets in user container"
 copy_token_to_notebook /srv/side-container/eos/krb5cc /srv/notebook/tokens/krb5cc
 copy_token_to_notebook /srv/side-container/eos/krb5cc /srv/notebook/tokens/writable/krb5cc_nb_term
 klist -c /srv/notebook/tokens/krb5cc
+
+# Install diff to use it below
+dnf install -y diffutils
+
 while true; do
     sleep $CULL_PERIOD
 


### PR DESCRIPTION
Since now the side-container uses Alma9 as image, which does not include diff by default.