### PR TITLE
[swan-cern] Use notebook container image for sidecar container

### DIFF
--- a/swan-cern/files/private/side_container_tokens_perm.sh
+++ b/swan-cern/files/private/side_container_tokens_perm.sh
@@ -46,9 +46,6 @@ copy_token_to_notebook /srv/side-container/eos/krb5cc /srv/notebook/tokens/krb5c
 copy_token_to_notebook /srv/side-container/eos/krb5cc /srv/notebook/tokens/writable/krb5cc_nb_term
 klist -c /srv/notebook/tokens/krb5cc
 
-# Install diff to use it below
-dnf install -y diffutils
-
 while true; do
     sleep $CULL_PERIOD
 

--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -193,7 +193,7 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
         pod_spec_containers.append(
             V1Container(
                 name='side-container',
-                image='gitlab-registry.cern.ch/linuxsupport/alma9-base:20240801-1',
+                image=notebook_container.image,
                 command=['/srv/side-container/side_container_tokens_perm.sh'],
                 args=[
                     env['USER_ID'],


### PR DESCRIPTION
Since such image will be pulled anyway for its use by the user pod, and it includes already the diffutils package that is required by the script that renews the EOS tickets (no need to install it dynamically anymore).