### PR TITLE
swan: Use harbor cache to pull docker images

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -79,6 +79,9 @@ jupyterhub:
   proxy:
     service:
       type: ClusterIP
+    secretSync:
+      image:
+        name: "registry.cern.ch/quay.io/jupyterhub/k8s-secret-sync"
     chp:
       networkPolicy:
         enabled: true
@@ -88,7 +91,7 @@ jupyterhub:
           dnsPortsPrivateIPs: false
           privateIPs: false
       image:
-        name: "jupyterhub/configurable-http-proxy"
+        name: "registry.cern.ch/quay.io/jupyterhub/configurable-http-proxy"
         tag: "4.5.0"
         pullPolicy: "IfNotPresent"
       resources:
@@ -201,6 +204,8 @@ jupyterhub:
   prePuller:
     hook:
       enabled: true
+      image:
+        name: "registry.cern.ch/quay.io/jupyterhub/k8s-image-awaiter"
     continuous:
       enabled: false
     containerSecurityContext:

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -92,7 +92,6 @@ jupyterhub:
           privateIPs: false
       image:
         name: "registry.cern.ch/quay.io/jupyterhub/configurable-http-proxy"
-        tag: "4.5.0"
         pullPolicy: "IfNotPresent"
       resources:
         requests:


### PR DESCRIPTION
This is because dockerhub and other registries impose rate limits when pulling images from their repositories.