### PR TITLE
swan: Add secret template for proxy https

### DIFF
--- a/swan/templates/secrets.yaml
+++ b/swan/templates/secrets.yaml
@@ -22,3 +22,15 @@ data:
   tls.key: {{ (required "helm --set swan.secrets.ingress.key=$(base64 -w0 <path>)" $.Values.swan.secrets.ingress.key) }}
 {{ end }}
 {{ end }}
+---
+{{ if .Values.jupyterhub.proxy.https.enabled }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ .Values.jupyterhub.proxy.https.secret.name }}
+  namespace: {{ $.Release.Namespace }}
+data:
+  tls.crt: {{ (required "helm --set swan.secrets.proxy.https.cert=$(base64 -w0 <path>)" $.Values.swan.secrets.proxy.https.cert) }}
+  tls.key: {{ (required "helm --set swan.secrets.proxy.https.key=$(base64 -w0 <path>)" $.Values.swan.secrets.proxy.https.key) }}
+{{ end }}


### PR DESCRIPTION
Add template to create TLS secret if the proxy https is enabled, instead of the ingress deployed by the JupyterHub chart.