### PR TITLE
[swan,swan-cern] Allocate the GPU flavour selected by the user

### DIFF
--- a/swan/templates/rbac.yaml
+++ b/swan/templates/rbac.yaml
@@ -20,3 +20,25 @@ roleRef:
   kind: Role
   name: swan
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: swan
+rules:
+  - apiGroups: [""]       # "" indicates the core API group
+    resources: ["nodes"]
+    verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: swan
+subjects:
+  - kind: ServiceAccount
+    name: hub
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: swan
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This is the charts side of a series of changes that allow the user to select a GPU flavour in the web form before starting their session.

When receiving the GPU selection from the user, a call to the k8s API is done to retrieve all the pods that have allocated a GPU. With such information, combined with the information about available GPU flavours in the cluster, we can see if the requested GPU flavour is free. If not, the user gets a message with all the free flavours (if any).

These changes also include adding extra capabilities to the hub service account to be able to get information about nodes in the cluster. This is necessary to retrieve the available GPU flavours in the cluster, which are currently specified as node labels.

