### PR TITLE
swan-cern-system: Pull docker.io image through CERN registry

### DIFF
--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -1,4 +1,6 @@
 fluentd:
+  image:
+    repository: registry.cern.ch/docker.io/fluent/fluentd-kubernetes-daemonset
   caCertPath: &fluentdCaCertPath /etc/ssl/ca-bundle.crt
   plugins:
     - fluent-plugin-rewrite-tag-filter


### PR DESCRIPTION
This change is due to the existence of rate limits when pulling images from docker.io. By pulling the image from the CERN registry, it will stay cached, without the need to always pull it from docker.io