### PR TITLE
Custom rules for Falco

### DIFF
--- a/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
+++ b/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
@@ -24,15 +24,37 @@ data:
           </rule>
           <rule>
               key $.kubernetes.pod_name
+              pattern /.*-falco-.*/
+              tag falco
+          </rule>
+          <rule>
+              key $.kubernetes.namespace_name
+              pattern /kube-system/
+              tag system
+          </rule>
+          <rule>
+              key $.kubernetes.pod_name
               pattern /.?/
               tag logs
           </rule>
       </match>
+ 
+      {{ if not .Values.fluentd.output.includeInternal }}
+        <match {system}>
+            @type null
+        </match>
+      {{ end }}
+
+      {{ if not .Values.fluentd.output.includeFalco }}
+        <match {falco}>
+            @type null
+        </match>
+      {{ end }}
 
       # Retag user and hub logs to:
       # - metrics: jupyter and jupyterhub custom log messages, used to emit metrics
       # - logs: rest of log messages
-      <match {user,hub}>
+      <match {user,hub,falco}>
           @type rewrite_tag_filter
           capitalize_regex_backreference true
           <rule>

--- a/swan-cern-system/templates/fluentd/fluentd_sources.conf.yaml
+++ b/swan-cern-system/templates/fluentd/fluentd_sources.conf.yaml
@@ -10,12 +10,6 @@ data:
           @type null
       </match>
 
-      {{ if not .Values.fluentd.output.includeInternal }}
-      <match kubernetes.var.log.containers.**_kube-system_**>
-          @type null
-      </match>
-      {{ end }}  
-
       # Read from container logs
       <source>
           @type tail

--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -10,6 +10,7 @@ fluentd:
   containerRuntime: containerd
   output:
     includeInternal: false
+    includeFalco: true
     cacert: *fluentdCaCertPath
   configMapConfigs:
     - fluentd-prometheus-conf # Preserve prometheus config for probes to work

--- a/swan-cern/README.md
+++ b/swan-cern/README.md
@@ -203,6 +203,16 @@ rmmod nouveau
 kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta4/nvidia-device-plugin.yml
 ```
 
+### Provide custom rules for Falco deployment
+
+Create a custom rules file `falco-custom-rules.yaml` and encode it in **base64**. Then, through Magum, provide the encoded file as a label to the Falco chart. This way, the custom rules will be loaded and used by Falco.
+
+For more information, read the [CERN Kubernetes Documentation](https://kubernetes.docs.cern.ch/docs/security/falco/#writing-your-own-alerts).
+
+```bash
+--labels cern_chart_user_values="$(cat falco-custom-rules.yaml | base64 -w0)" \
+```
+
 ### Demo of upstream JupyterHub (no SWAN, no EOS, no CVMFS)
 This option uses upstream [JupyterHub Helm Chart](https://jupyterhub.github.io/helm-chart/)
 

--- a/swan-cern/templates/falco-custom-rules.yaml
+++ b/swan-cern/templates/falco-custom-rules.yaml
@@ -1,0 +1,49 @@
+customRules:
+    user_pod_rules.yaml: |-
+      - list: ignored_networks
+        items: ['"127.0.0.1/8"']
+
+      - macro: connection_filter
+        condition: >
+          fd.l4proto = tcp and (fd.typechar = 4 or fd.typechar = 6) and
+          (fd.ip != "0.0.0.0" and not fd.snet in (ignored_networks))
+
+      - macro: outbound_connection_tcp
+        condition: evt.type = connect and connection_filter and (evt.rawres >= 0 or evt.res = EINPROGRESS)
+      - macro: inbound_connection_tcp
+        condition: evt.type = accept and connection_filter
+
+      - macro: user_pod
+        condition: >
+          container
+          and k8s.pod.name startswith "jupyter-"
+          and k8s.ns.name = swan
+
+      - rule: Contact K8S API Server From Container
+        enabled: false
+        override:
+          enabled: replace
+
+      - rule: Log User Commands in Jupyter Pod
+        desc: Logs all commands executed by the user
+        condition: user_pod and spawned_process
+        output: >
+          exec_path: %proc.exepath --- args: %proc.args --- pname: %proc.pname (%container.info)
+        priority: NOTICE
+        tags: [user_activity, command_execution]
+
+      - rule: Detect Incoming Connections in Jupyter Pod
+        desc: Detects when a process initiates an inbound network connection
+        condition: user_pod and inbound_connection_tcp
+        output: >
+          Incoming connection [%proc.name - %proc.pname]: %fd.rip:%fd.rport -> %fd.lip:%fd.lport (%container.info)
+        priority: NOTICE
+        tags: [user_activity, network, incoming]
+
+      - rule: Detect Outgoing Connections in Jupyter Pod
+        desc: Detects when a process initiates an outbound network connection
+        condition: user_pod and outbound_connection_tcp
+        output: >
+          Outgoing connection [%proc.name - %proc.pname]: %fd.lip:%fd.lport -> %fd.rip:%fd.rport (%container.info)
+        priority: NOTICE
+        tags: [user_activity, network, outgoing]


### PR DESCRIPTION
These two rules are made for tracking users activity, including:
- Logging each executed command via jupyter terminal;
- Logging every incoming and outcoming connection established with the user's pod.

The change on grok rules is made for not allowing the filtering rules to ignore falco logs (because falco pods are deployed within the kube-system namespace, which is being currently ignored by the `ignoreInternal` value). So a new value `internalFalco` was created in order to open an exception to this generic rule.
