### PR TITLE
swan-cern: Change analytix cluster name to hadoop-analytix

### DIFF
--- a/swan-cern/files/swan_computing_config.py
+++ b/swan-cern/files/swan_computing_config.py
@@ -148,7 +148,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
         k8suser_config_base64 = ''
 
         if cluster == 'k8s':
-            hdfs_cluster = 'analytix'
+            hdfs_cluster = 'hadoop-analytix'
             try:
                 # Setup the user and generate user kube config
                 k8suser_config_base64 = subprocess.check_output(
@@ -254,7 +254,7 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
         user_roles = self.spawner.user_roles
         cluster = self.spawner.user_options[self.spawner.spark_cluster_field]
 
-        if cluster == "analytix" and "analytix" not in user_roles:
+        if cluster == "hadoop-analytix" and "analytix" not in user_roles:
            raise ValueError(
               """
               Access to the Analytix cluster is not granted. 


### PR DESCRIPTION
This is following a change of name and paths made by the hadoop team