### PR TITLE
swan-cern: Update hadoop token generator to v3.0.5

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -236,4 +236,4 @@ swanCern:
       cred:
 
 hadoopTokenGenerator:
-  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v3.0.4
+  image: gitlab-registry.cern.ch/swan/docker-images/hadoop-token-generator:v3.0.5


### PR DESCRIPTION
To adapt to new hadoop-analytix nomenclature.