### PR TITLE
Remove offline_access scope from KeyCloakAuthenticator

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -146,7 +146,6 @@ jupyterhub:
         scope:
           - profile
           - email
-          - offline_access
           - openid
         exchange_tokens: []
         auto_login: True


### PR DESCRIPTION
Allows to prevent silent re-login after the refresh token expired. 