### PR TITLE
Revert "Remove offline_access scope from KeyCloakAuthenticator to enf…

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -146,6 +146,7 @@ jupyterhub:
         scope:
           - profile
           - email
+          - offline_access
           - openid
         exchange_tokens: []
         auto_login: True


### PR DESCRIPTION
…orce 12h token expiry"

This reverts commit d5207a882668ef5fcfdeb7889a0a11b736d5d5c1.

In order to fulfill the session times security rule, we will implement a mechanism to terminate user sessions every 12h if the user has been blocked. Therefore, we do not need to remove the offline_access scope, which would trigger expiration of refresh tokens every 12h.