### PR TITLE
swan-cern-system: New includeFalco value

### DIFF
--- a/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
+++ b/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
@@ -24,15 +24,37 @@ data:
           </rule>
           <rule>
               key $.kubernetes.pod_name
+              pattern /.*-falco-.*/
+              tag falco
+          </rule>
+          <rule>
+              key $.kubernetes.namespace_name
+              pattern /kube-system/
+              tag system
+          </rule>
+          <rule>
+              key $.kubernetes.pod_name
               pattern /.?/
               tag logs
           </rule>
       </match>
+ 
+      {{ if not .Values.fluentd.output.includeInternal }}
+        <match {system}>
+            @type null
+        </match>
+      {{ end }}
+
+      {{ if not .Values.fluentd.output.includeFalco }}
+        <match {falco}>
+            @type null
+        </match>
+      {{ end }}
 
       # Retag user and hub logs to:
       # - metrics: jupyter and jupyterhub custom log messages, used to emit metrics
       # - logs: rest of log messages
-      <match {user,hub}>
+      <match {user,hub,falco}>
           @type rewrite_tag_filter
           capitalize_regex_backreference true
           <rule>

--- a/swan-cern-system/templates/fluentd/fluentd_sources.conf.yaml
+++ b/swan-cern-system/templates/fluentd/fluentd_sources.conf.yaml
@@ -10,12 +10,6 @@ data:
           @type null
       </match>
 
-      {{ if not .Values.fluentd.output.includeInternal }}
-      <match kubernetes.var.log.containers.**_kube-system_**>
-          @type null
-      </match>
-      {{ end }}  
-
       # Read from container logs
       <source>
           @type tail

--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -10,6 +10,7 @@ fluentd:
   containerRuntime: containerd
   output:
     includeInternal: false
+    includeFalco: false
     cacert: *fluentdCaCertPath
   configMapConfigs:
     - fluentd-prometheus-conf # Preserve prometheus config for probes to work


### PR DESCRIPTION
This change is made for not allowing the filtering rules to ignore falco logs (because falco pods are deployed within the kube-system namespace, which is being currently ignored by the `ignoreInternal` value). So a new value `internalFalco` was created in order to open an exception to this generic rule.