### PR TITLE
swan-cern-system: Add fluentd tag to differentiate logs

### DIFF
--- a/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
+++ b/swan-cern-system/templates/fluentd/fluentd_filters.conf.yaml
@@ -147,6 +147,7 @@ data:
           <record>
               timestamp ${(time.to_f * 1000).to_i}
               producer {{ .Values.fluentd.output.producer }}
+              community {{ .Values.community }}
               raw ${record["log"]} # field named raw is indexed by MONIT/OpenSearch
           </record>
           remove_keys ["log"]


### PR DESCRIPTION
Add new community tag to differentiate and filter logs coming from different instances of SWAN, such as the general instance and the ATS one while using the production and qa monit producers