### PR TITLE
liqo-peering: fix -  add annotation for oracle NLB

### DIFF
--- a/liqo-peering/templates/gateway-server.yaml
+++ b/liqo-peering/templates/gateway-server.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: {{ include "liqo.tenantNamespace" . }}
   labels:
     liqo.io/remote-cluster-id: {{ .Values.remoteCluster.clusterId }}
+  annotations:
+    oci.oraclecloud.com/load-balancer-type: "nlb"
 spec:
   endpoint:
     loadBalancerIP: {{ .Values.gateway.loadBalancerIp }}


### PR DESCRIPTION
Allow the creation of Network load balancer for networking in Oracle cloud