### PR TITLE
swan-cern: Set external traffic policy to local on computing ports service

### DIFF
--- a/swan-cern/files/swan_computing_config.py
+++ b/swan-cern/files/swan_computing_config.py
@@ -367,7 +367,10 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
                 spec=V1ServiceSpec(
                     selector=self.pod.metadata.labels,  # attach this service to the user pod
                     ports=service_template_ports,
-                    type="NodePort"
+                    type="NodePort",
+                    # To preserve the source IP of the incoming connection,
+                    # so that it is possible to connect to the Spark WebUI
+                    external_traffic_policy="Local"
                 )
             )
 


### PR DESCRIPTION
This change allows to preserve the source IP of incoming requests which permits to display the Spark WebUI to the user, as this contains a list of authorized IP addresses that are able to connect to it

It fixes the issue of Spark users not being able to connect to the Spark WebUI