### PR TITLE
[swan-cern]: add options to implement new logic in the culler for blocked users

### DIFF
--- a/swan-cern/files/swan_computing_config.py
+++ b/swan-cern/files/swan_computing_config.py
@@ -116,6 +116,18 @@ class SwanComputingPodHookHandler(SwanPodHookHandlerProd):
 
             # Request generic GPU resource name
             gpu_resource_name = 'nvidia.com/gpu'
+            
+            # Allow scheduling on Oracle for any user requesting a GPU
+            tolerations = self.pod.spec.tolerations or []
+            tolerations.append(
+                V1Toleration(
+                    key="oracle/gpu",
+                    operator="Equal",
+                    value="true",
+                    effect="NoSchedule"
+                )
+            )
+            self.pod.spec.tolerations = tolerations
 
         # Add to notebook container the requests and limits for the GPU
         notebook_container = self._get_pod_container('notebook')

--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -240,10 +240,18 @@ swan:
                     kubernetes.io/metadata.name: kube-system
     custom:
       cull:
+        enabled: true
+        every: 600
         # 4 hours
         timeout: 14400
+        users: true
         checkEosAuth: true
         hooksDir: /srv/jupyterhub/culler
+        audience: 'authorization-service-api'
+        auth_url: https://auth.cern.ch/auth/realms/cern/api-access/token
+        authz_api_url: https://authorization-service-api.web.cern.ch/api/v1.0/Identity
+        # 12 hours
+        auth_check_interval: 43200 
       spark:
         configurationPath: /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext
 swanCern:

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -70,7 +70,7 @@ class SwanPodHookHandler:
         return list
 
 # https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html
-# This is defined in the configuration to allow overring iindependently 
+# This is defined in the configuration to allow overring independently 
 # of which config file is loaded first
 # c.SwanKubeSpawner.modify_pod_hook = swan_pod_hook
 def swan_pod_hook(spawner, pod):
@@ -102,63 +102,6 @@ c.SwanKubeSpawner.modify_pod_hook = swan_pod_hook
 #             'url': 'http://hub:8989'
 #         }
 #     )
-
-# Culling of users and ticket refresh
-if get_config("custom.cull.enabled", False):
-    swan_idle_culler_role = {
-        "name": "swan-idle-culler",
-        "scopes": [
-            "list:users",
-            "read:users:activity",
-            "read:servers",
-            "delete:servers",
-            # "admin:users", # dynamically added if --cull-users is passed
-        ],
-        # assign the role to a jupyterhub service, so it gains these permissions
-        "services": ["swan-idle-culler"],
-    }
-
-    cull_cmd = ["swanculler"]
-    base_url = c.JupyterHub.get("base_url", "/")
-    cull_cmd.append("--url=http://localhost:8081" + url_path_join(base_url, "hub/api"))
-
-    cull_timeout = get_config("custom.cull.timeout")
-    if cull_timeout:
-        cull_cmd.append("--timeout=%s" % cull_timeout)
-
-    cull_every = get_config("custom.cull.every")
-    if cull_every:
-        cull_cmd.append("--cull-every=%s" % cull_every)
-
-    if get_config("custom.cull.users"):
-        cull_cmd.append("--cull-users=True")
-        swan_idle_culler_role["scopes"].append("admin:users")
-
-    if get_config("custom.cull.removeNamedServers"):
-        cull_cmd.append("--remove-named-servers")
-
-    cull_max_age = get_config("custom.cull.maxAge")
-    if cull_max_age:
-        cull_cmd.append("--max-age=%s" % cull_max_age)
-    
-    check_eos = get_config('custom.cull.checkEosAuth', False)
-    if not check_eos:
-        cull_cmd.append("--disable-hooks=True")
-    
-    hooks_dir = get_config('custom.cull.hooksDir')
-    if hooks_dir:
-        cull_cmd.append(f"--hooks-dir={hooks_dir}")
-
-    c.JupyterHub.services.append(
-        {
-            "name": "swan-idle-culler",
-            "admin": True,
-            "command": cull_cmd,
-            "environment": {'SWAN_DEV': os.environ.get('SWAN_DEV', 'false')}
-        }
-    )
-    c.JupyterHub.load_roles.append(swan_idle_culler_role)
-
 
 # Init lists for volumes and volume_mounts
 c.SwanKubeSpawner.volumes = []

--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -219,13 +219,6 @@ jupyterhub:
   cull:
     enabled: false
   custom:
-    cull:
-      enabled: true
-      every: 600
-      # 2 hours
-      timeout: 7200
-      users: true
-      checkEosAuth: false
     eos:
       enabled: *eosEnabled
 # placeholders for swan credentials


### PR DESCRIPTION
Add options to implement new logic in the culler that detects, every 12 hours, which users have been blocked.