### PR TITLE
swan-cern: Change prometheus network policy namespace to swan-cern-system

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -237,7 +237,7 @@ swan:
                     app.kubernetes.io/name: prometheus
                 namespaceSelector:
                   matchLabels:
-                    kubernetes.io/metadata.name: kube-system
+                    kubernetes.io/metadata.name: swan-cern-system
     custom:
       cull:
         enabled: true


### PR DESCRIPTION
Prometheus will be deployed through the swan-cern-system chart (using the monitoring one as dependency) in the swan-cern-system namespace. Therefore, the policy needs to be updated to allow connections from such namespace