### PR TITLE
Draft: swan-cern-system: Add kafka-streams-apps chart as dependency

### DIFF
--- a/swan-cern-system/Chart.lock
+++ b/swan-cern-system/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: cern-it-monitoring-kubernetes
   repository: oci://registry.cern.ch/monit
   version: 3.1.0
-digest: sha256:64c28a46094cd9279de0264efcd365bf8c4887b459675d7f16f0b0dfc369bd32
-generated: "2025-06-12T15:48:27.772610288+02:00"
+- name: kafka-streams-apps
+  repository: oci://registry.cern.ch/swan/charts
+  version: 0.0.1
+digest: sha256:7ffa850a556967541d6f62860d41c2f4b646dc99e3dd7c5aff720b021209f0e2
+generated: "2025-06-20T14:42:33.110983238+02:00"

--- a/swan-cern-system/Chart.yaml
+++ b/swan-cern-system/Chart.yaml
@@ -17,3 +17,7 @@ dependencies:
     version: 3.1.0
     repository: oci://registry.cern.ch/monit
     condition: cern-it-monitoring-kubernetes.enabled
+  - name: kafka-streams-apps
+    version: 0.0.1
+    repository: oci://registry.cern.ch/swan/charts
+    condition: kafka-streams-apps.affiliation.enabled

--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -256,3 +256,7 @@ cern-it-monitoring-kubernetes:
 
             return 1, timestamp, record
           end
+
+kafka-streams-apps:
+  affiliation:
+    enabled: true


### PR DESCRIPTION
The kafka-streams-apps chart is responsible to deploy an enricher of metrics, to include the information of the affiliation of each user that accesses the service to the corresponding metrics

This will be used for statistical purposes and the metrics will be enriched when sent to specific kafka topics, defined in the chart