### PR TITLE
swan-cern-system: Change prometheus rules according to new monitoring chart

### DIFF
--- a/swan-cern-system/templates/prometheus/rules.yaml
+++ b/swan-cern-system/templates/prometheus/rules.yaml
@@ -3,7 +3,6 @@ kind: PrometheusRule
 metadata:
   labels:
     app: prometheus
-    release: cern-magnum
   name: swan.rules
   namespace: {{ .Release.Namespace }}
 spec:
@@ -11,9 +10,9 @@ spec:
   - interval: 24h
     name: swan.rules.users
     rules:
-    - expr: count(last_over_time(kube_pod_status_phase{namespace="swan",phase="Running",pod=~"jupyter-[a-z]+"}[24h])>0) by (pod)
+    - expr: count(last_over_time(kube_pod_status_phase{exported_namespace="swan",phase="Running",exported_pod=~"jupyter-[a-z]+"}[24h])>0) by (exported_pod)
       record: swan:users:unique:list:daily
-    - expr: max_over_time(count(count(kube_pod_status_phase{namespace="swan",phase="Running",pod=~"jupyter-[a-z]+"}>0) by (pod))[24h:5m])
+    - expr: max_over_time(count(count(kube_pod_status_phase{exported_namespace="swan",phase="Running",exported_pod=~"jupyter-[a-z]+"}>0) by (exported_pod))[24h:5m])
       record: swan:users:peak:daily
     - expr: count(last_over_time(kube_pod_container_resource_requests{resource=~"nvidia_com_(gpu|mig.+)"}[24h])) by (pod)
       record: swan:users:gpu:unique:list:daily

--- a/swan-cern-system/templates/prometheus/rules.yaml
+++ b/swan-cern-system/templates/prometheus/rules.yaml
@@ -11,10 +11,10 @@ spec:
     name: swan.rules.users
     rules:
     - expr: count(last_over_time(kube_pod_status_phase{exported_namespace="swan",phase="Running",exported_pod=~"jupyter-[a-z]+"}[24h])>0) by (exported_pod)
-      record: swan:users:unique:list:daily
+      record: swan:users:unique:list:daily:raw
     - expr: max_over_time(count(count(kube_pod_status_phase{exported_namespace="swan",phase="Running",exported_pod=~"jupyter-[a-z]+"}>0) by (exported_pod))[24h:5m])
       record: swan:users:peak:daily
-    - expr: count(last_over_time(kube_pod_container_resource_requests{resource=~"nvidia_com_(gpu|mig.+)"}[24h])) by (pod)
-      record: swan:users:gpu:unique:list:daily
-    - expr: max_over_time(count(count(kube_pod_container_resource_requests{resource=~"nvidia_com_(gpu|mig.+)"}) by(pod))[24h:5m])
+    - expr: count(last_over_time(kube_pod_container_resource_requests{resource=~"nvidia_com_(gpu|mig.+)"}[24h])) by (exported_pod)
+      record: swan:users:gpu:unique:list:daily:raw
+    - expr: max_over_time(count(count(kube_pod_container_resource_requests{resource=~"nvidia_com_(gpu|mig.+)"}) by(exported_pod))[24h:5m])
       record: swan:users:gpu:peak:daily


### PR DESCRIPTION
Change labels to the new ones exported by the monitoring chart. Furthermore, remove the cern-magnum release label, as Prometheus is no longer deployed through cern-magnum.

Do not merge until the new chart of monitoring is deployed in production.