### PR TITLE
swan-cern-system: Disable kafka-streams-apps by default

### DIFF
--- a/swan-cern-system/values.yaml
+++ b/swan-cern-system/values.yaml
@@ -259,4 +259,4 @@ cern-it-monitoring-kubernetes:
 
 kafka-streams-apps:
   affiliation:
-    enabled: true
+    enabled: false


### PR DESCRIPTION
This will only be deployed in production after the monitoring chart is also deployed. Since it is currently disabled, this needs to be disabled as well