### PR TITLE
[swan-cern] fix(networkpolicy): add egress rule for port 6443 

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -226,6 +226,9 @@ swan:
           scopes: ['read:metrics']
           services: [prometheus-service-monitor]
       networkPolicy:
+        egress:
+          - ports:
+              - port: 6443
         ingress:
           # Allow connection from prometheus to the hub, to scrape the metrics endpoint
           - ports:


### PR DESCRIPTION
add egress rule for port 6443 to fix connectivity with Cilium, cf issue: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3202 