### PR TITLE
swan-cern: Apply same structure is being used for `swan-cern` image

### DIFF
--- a/swan-cern/values.yaml
+++ b/swan-cern/values.yaml
@@ -186,7 +186,10 @@ swan:
         SwanKubeSpawner:
           # memory request for user pod (fraction of the limit)
           mem_request_fraction: 0.6
-          accpy_image: "gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-accpy:v0.0.8"
+          accpy:
+            image:
+              name: gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-accpy
+              tag: v0.0.8
         SwanSpawner:
           ats_role: "swan-ats"
         SpawnHandlersConfigs:


### PR DESCRIPTION
This is made for applying the same CI over swan-accpy in a easier way