### PR TITLE
swan: Pull hub and user images only if not present

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -53,7 +53,7 @@ jupyterhub:
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyter/swan"
       tag: "v0.0.14"
-      pullPolicy: "Always"
+      pullPolicy: "IfNotPresent"
     cloudMetadata:
       blockWithIptables: false
       ip: 169.254.169.254
@@ -125,7 +125,7 @@ jupyterhub:
     image:
       name: "gitlab-registry.cern.ch/swan/docker-images/jupyterhub"
       tag: v3.43
-      pullPolicy: "Always"
+      pullPolicy: "IfNotPresent"
     extraVolumeMounts:
       - name: swan-jh
         mountPath: /srv/jupyterhub/options_form_config.json


### PR DESCRIPTION
Change pull policy for the JupyterHub and User images to be pulled only if not present in the node.
This ensures the service will continue to run normally even if there are issues with the docker registries from where the images are pulled from