### PR TITLE
Silence uv warning about missing requirements.txt

### DIFF
--- a/.github/workflows/tag-chart.yaml
+++ b/.github/workflows/tag-chart.yaml
@@ -49,6 +49,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: 3.14
+          enable-cache: false # Silence a warning about missing requirements.txt/pyproject.toml files in the repository
 
       - name: Fetch chart dependencies
         run: helm dependency update ${{ inputs.chart }}


### PR DESCRIPTION
The warning in question: https://github.com/swan-cern/swan-charts/actions/runs/23793937206

```
No file matched to [/home/runner/work/swan-charts/swan-charts/**/*requirements*.txt,/home/runner/work/swan-charts/swan-charts/**/*requirements*.in,/home/runner/work/swan-charts/swan-charts/**/*constraints*.txt,/home/runner/work/swan-charts/swan-charts/**/*constraints*.in,/home/runner/work/swan-charts/swan-charts/**/pyproject.toml,/home/runner/work/swan-charts/swan-charts/**/uv.lock,/home/runner/work/swan-charts/swan-charts/**/*.py.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.
```