### PR TITLE
Make it possible to run with EOS disabled

### DIFF
--- a/swan-cern/files/swan_config_cern.py
+++ b/swan-cern/files/swan_config_cern.py
@@ -29,19 +29,15 @@ class SwanPodHookHandlerProd(SwanPodHookHandler):
     async def get_swan_user_pod(self):
         super().get_swan_user_pod()
 
-        # ATTENTION Spark requires this side container, so we need to create it!!
-        # Check if we should add the EOS path in the firstplace
-        # if hasattr(self.spawner, 'local_home') and \
-        #     not self.spawner.local_home:
-
         # Check if the user has access to the Technical Network
         self._check_tn_access()
 
-        # get eos token
-        eos_secret_name = await self._init_eos_secret()
-
-        # init user containers (notebook and side-container)
-        self._init_eos_containers(eos_secret_name)
+        # When eos is enabled, create eos token and side-container for token refresh
+        # Note: Spark also requires the side container so Spark is disabled when EOS is disabled.
+        eos_enabled = get_config("custom.eos.enabled", False)
+        if eos_enabled:
+            eos_secret_name = await self._init_eos_secret()
+            self._init_eos_containers(eos_secret_name)
 
         return self.pod
 

--- a/swan/files/swan_config.py
+++ b/swan/files/swan_config.py
@@ -123,8 +123,13 @@ c.SwanKubeSpawner.volume_mounts.append(
     )
 )
 
+eos_enabled = get_config("custom.eos.enabled", False)
+
+# Propagate EOS availability to user pods
+c.SwanKubeSpawner.environment.update({'EOS_ENABLED': str(eos_enabled).lower()})
+
 # Manage EOS access
-if get_config("custom.eos.enabled", False):
+if eos_enabled:
     c.SwanKubeSpawner.volumes.append(
         V1Volume(
             name='eos',
@@ -141,9 +146,9 @@ if get_config("custom.eos.enabled", False):
         )
     )
 else:
-    # No access to EOS provided
-    logging.warn("EOS access not provided. Make sure you use a scratch space as home directory (local_home: true)")
-    pass
+    # No access to EOS provided, congfigure HOME to point to /home/<user> instead of EOS HOME.
+    c.SwanKubeSpawner.local_home = True
+    c.SpawnHandlersConfigs.local_home = True
 
 # Manage CVMFS access
 c.SwanKubeSpawner.volumes.append(


### PR DESCRIPTION
For the EOSC node, since users might have a CERN account, we do not want to expose EOS (and users might not have access to it anyway without a regular CERN account). We should make it possible to run SWAN without EOS. At least for now, this means no persistent storage at all.

This is basically the minimum set of changes that let's us spawn a session without EOS, though we might still a need a change or two in the start up scripts in jupyter-images and the kube spawner.

There was already `custom.eos.enabled` so I reused that. In addition, we also already have the `local_home` trait, which sets `HOME` to `/home/<user>` instead of EOS home.