### PR TITLE
swan: Remove unused env var

### DIFF
--- a/swan/values.yaml
+++ b/swan/values.yaml
@@ -68,8 +68,6 @@ jupyterhub:
         name: "registry.cern.ch/quay.io/jupyterhub/k8s-network-tools"
     extraAnnotations:
       kubectl.kubernetes.io/default-container: notebook
-    extraEnv:
-      SWAN_DISABLE_NOTIFICATIONS: "true"
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
I don't think this is used anywhere? (I couldn't find any uses across our repos)