### PR TITLE
ci: Fix image update script for prefetcher

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -37,7 +37,7 @@ jobs:
         IMAGE_NAME="${IMAGE}"
         IMAGE_VERSION="${VERSION}"
         echo "Updating information for image = $IMAGE_NAME version = $IMAGE_VERSION"
-        sed -i -E "/^[[:space:]]*name:[[:space:]]*\"?gitlab-registry\.cern\.ch\/swan\/docker-images\/${IMAGE_NAME//\//\\/}\"?[[:space:]]*$/ { n; s/^([[:space:]]*)tag:[[:space:]]*\"?[^\"]*\"?/\1tag: ${IMAGE_VERSION}/ }" swan/values.yaml swan-cern/values.yaml
+        sed -i -E "/^[[:space:]]*(name|repository):[[:space:]]*\"?gitlab-registry\.cern\.ch\/swan\/docker-images\/${IMAGE_NAME//\//\\/}\"?[[:space:]]*$/ { n; s/^([[:space:]]*)tag:[[:space:]]*\"?[^\"]*\"?/\1tag: ${IMAGE_VERSION}/ }" swan/values.yaml swan-cern/values.yaml
 
     - name: Create Pull Request
       env:


### PR DESCRIPTION
The prefetcher image is defined using the `repository` key as opposed to all the other images defined as `image: ...`.
It caused this CI run to fail when updating the prefetcher version: https://github.com/swan-cern/swan-charts/actions/runs/27412784159/job/81017902379